### PR TITLE
Allow non-root users to run this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ This project utilizes KVM to create a OpenShift Cluster running in VMs.  This
 project runs on baremetal servers as well as PowerVM and PowerVS based servers
 provided that a large enough LPAR is allocated.
 
+## User Requirements
+
+This project may be run by non-root users with **sudo** authority.
+*passwordless* sudo access should be setup for this user, so that the scripts
+don't prompt for a password while running.  A helper script is provided
+for this purpose at **scripts/helper/set-passwordless-sudo.sh**.  There are no
+command arguments for this script and it should be run once during initial setup.
+
+Non-root users must use the **sudo** command with **virsh** to see VMs.
+
 ## Scripts
 
 - create-ocp.sh [ --retry ]
@@ -27,7 +37,7 @@ provided that a large enough LPAR is allocated.
 - teardown-ocs-ci.sh
 
 The scripts above correspond to high level tasks of OCS-CI.  They are intended to
-be invoked from an automation test script such as might be deployed with Jenkins
+be invoked from an automation test script such as Jenkins
 and are designed to run unattended.  The scripts are listed in the order that
 they are expected to be run.
 
@@ -36,12 +46,12 @@ github.com/red-hat-storage/ocs-ci.  This project should be cloned to instantiate
 submodules as shown below.
   
 ```
-git clone https://github.com/ocp-power-automation/ocs-upi-kvm --recursive /root/ocs-upi-kvm
+git clone https://github.com/ocp-power-automation/ocs-upi-kvm --recursive
 
 OR
 
-git clone https://github.com/ocp-power-automation/ocs-upi-kvm.sh /root/ocs-upi-kvm
-cd /root/ocs-upi-kvm
+git clone https://github.com/ocp-power-automation/ocs-upi-kvm.sh
+cd ocs-upi-kvm
 git submodule update --init
 ```
 The majority of the **create-ocp.sh** command is spent running terraform (and ansible).
@@ -72,7 +82,17 @@ data disks, while the script **jenkins-ocs-psi.sh** uses physical disk partions.
 - RHID_USERNAME=xxx
 - RHID_PASSWORD=yyy
 
+## Project Workspace
+
+This project is designed to be used in an automated test framework like Jenkins which utilizes
+dedicated workspaces to run jobs in parallel on the same server.  As such, all input, output,
+and internally generated files are restricted to the specific workspace instance that
+is allocated to run the job.  For this project, that workspace is assumed to be 
+the *parent* directory of the cloned project **ocs-upi-kvm** itself.
+
 ## Required Files
+
+These files should be placed in the workspace directory.
 
 - ~/auth.yaml
 - ~/pull-secret.txt
@@ -157,20 +177,53 @@ The environment variable FORCE_DISK_PARTITION_WIPE may be set to 'true' to wipe
 the data on a hard disk partition assuming the environment variable DATA_DISK_LIST is
 specified.  The wipe may take an hour or more to complete.
 
-## Post Install Setup
+## Post Install
 
-Add the following to the root user's profile to enable the use of the **oc** command.
+### Configure the use of the **oc** command
+
+Add the following to the user's profile to enable the use of the **oc** command.
 ```
-export KUBECONFIG=~/auth/kubeconfig
+export KUBECONFIG=<path-to-workspace>/auth/kubeconfig
+```
+As noted above, the parameter <path-to-workspace> is the *parent* directory
+of the **ocs-upi-kvm** directory.  For example, if ocs-upi-kvm is installed at
+~/workspace/ocs/ocs-upi-kvm, then the export statement would be:
+
+```
+export KUBECONFIG=~/workspace/ocs/auth/kubeconfig
 ```
 
-## Webconsole Support
+### Log Files
 
-Using the example above, on the remote server where you intend to use Firefox or Safari,
-add the following to your /etc/hosts file or MacOS equivalent.
+Several log files are located in the workspace.
+
+### Build artificacts including oc command and kubeconfig
+
+This project downloads and installs GO into the workspace.  It uses the go command to
+compile terraform and terraform Modules that are used during the creation of the OCP cluster.
+The versions of GO and Terraform are specific to the OCP release.  The scripts will
+automatically download and update these binaries as required.
+
+If you remove the workspace after the cluster is created, then you will not be able 
+to run the oc command as it is included in the workspace along with kubeconfig.  These
+are the relevant commands that should be relocated if you want to destroy the workspace
+after creating a cluster.  Again using the example cluster above:
+
 ```
-<ip kvm host server> console-openshift-console.apps.test-ocp4.5.tt.testing oauth-openshift.apps.test-ocp4.5.tt.testing
+cp ~workspace/ocs/bin ~/bin
+cp -r ~workspace/ocs/auth ~
+```
+
+### Remote Webconsole Support
+
+The cluster create command should output webconsole information which should look something
+like the first entry below.  The second entry which is related to oauth you will have to produce
+following the pattern shown below.  On the your laptop, you should add the console URL to your
+/etc/hosts file or MacOS equivalent defining the IP Address of the KVM server.
+
+```
+<ip kvm host server> console-openshift-console.apps.test-ocp4-5.tt.testing oauth-openshift.apps.test-ocp4-5.tt.testing
 ```
 The browser should prompt you to login to the OCP cluster.  The user name is kubeadmin and
-the password is located in the file /root/auth/kubeadmin-password on the KVM host server.
+the password is located in the file <path-to-workspace>/auth/kubeadmin-password on the KVM host server.
 

--- a/scripts/deploy-ocs-ci.sh
+++ b/scripts/deploy-ocs-ci.sh
@@ -1,36 +1,38 @@
 #!/bin/bash
 
-user=$(whoami)
-if [ "$user" != root ]; then
-        echo "This script must be invoked as root"
-        exit 1
-fi
-
-if [ ! -e ~/pull-secret.txt ]; then
-	echo "Missing ~/pull-secret.txt.  Download it from https://cloud.redhat.com/openshift/install/pull-secret"
+if [ ! -e helper/parameters.sh ]; then
+	echo "This script should be invoked from the directory ocs-upi-kvm/scripts"
 	exit 1
 fi
 
-if [ ! -e ~/auth.yaml ]; then
-	echo "~/auth.yaml is required"
+source helper/parameters.sh
+
+if [ ! -e $WORKSPACE/pull-secret.txt ]; then
+	echo "Missing $WORKSPACE/pull-secret.txt.  Download it from https://cloud.redhat.com/openshift/install/pull-secret"
 	exit 1
 fi
 
-source /root/venv/bin/activate                  # enter 'deactivate' in venv shell to exit
+if [ ! -e $WORKSPACE/auth.yaml ]; then
+	echo "$WORKSPACE/auth.yaml is required"
+	exit 1
+fi
 
-set -ex
+set -e
 
-export KUBECONFIG=~/auth/kubeconfig
+export KUBECONFIG=$WORKSPACE/auth/kubeconfig
 
-TOP_DIR=$(pwd)/..
-
-pushd $TOP_DIR/src/ocs-ci
+pushd ../src/ocs-ci
 
 mkdir -p data
 
-cp ~/auth.yaml data/auth.yaml
-cp ~/pull-secret.txt data/pull-secret
+cp $WORKSPACE/auth.yaml data/auth.yaml
+cp $WORKSPACE/pull-secret.txt data/pull-secret
 
-run-ci -m deployment --deploy --ocsci-conf=conf/ocsci/production_powervs_upi.yaml --ocs-version 4.6 --cluster-name=ocstest --cluster-path=/root --collect-logs
+source $WORKSPACE/venv/bin/activate                  # enter 'deactivate' in venv shell to exit
+
+run-ci -m deployment --deploy --ocsci-conf=conf/ocsci/production_powervs_upi.yaml --ocs-version 4.6 \
+       --cluster-name=ocstest --cluster-path=$WORKSPACE --collect-logs
+
+deactivate
 
 popd

--- a/scripts/destroy-ocp.sh
+++ b/scripts/destroy-ocp.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-user=$(whoami)
-if [ "$user" != root ]; then
-        echo "This script must be invoked as root"
-        exit 1
-fi
-
 set -e
 
 if [ ! -e helper/virsh-cleanup.sh ]; then
@@ -13,4 +7,4 @@ if [ ! -e helper/virsh-cleanup.sh ]; then
         exit 1
 fi
 
-helper/virsh-cleanup.sh
+sudo -s helper/virsh-cleanup.sh

--- a/scripts/helper/add-data-disks.sh
+++ b/scripts/helper/add-data-disks.sh
@@ -24,7 +24,7 @@ fi
 
 if [ -z "$DATA_DISK_ARRAY" ]; then
 	# Remember where data files will be created for virsh_cleanup.sh
-	echo "$IMAGES_PATH" > ~/.images_path
+	echo "$IMAGES_PATH" > $WORKSPACE/.images_path
 	# Remove old images in case virsh_cleanup.sh is not run
 	rm -f $IMAGES_PATH/test-ocp$SANITIZED_OCP_VERSION/*.data
 fi
@@ -61,7 +61,7 @@ for (( i=0; i<$WORKERS; i++ ))
 do
         vm=$(virsh list --all | grep worker-$i | awk '{print $2}' | tail -n 1)
 
-        ip=$(/usr/local/bin/oc get nodes -o wide | grep worker-$i | tail -n 1 | awk '{print $6}')
+        ip=$($WORKSPACE/bin/oc get nodes -o wide | grep worker-$i | tail -n 1 | awk '{print $6}')
 
         success=false
         for ((cnt=0; cnt<6; cnt++))

--- a/scripts/helper/check-health-cluster.sh
+++ b/scripts/helper/check-health-cluster.sh
@@ -28,7 +28,7 @@ function wait_vm_reboot ( ) {
         success=false
         for ((cnt=0; cnt<3; cnt++))
 	do
-        	ip=$(/usr/local/bin/oc get nodes -o wide | grep $vm | tail -n 1 | awk '{print $6}')
+		ip=$($WORKSPACE/bin/oc get nodes -o wide | grep $vm | tail -n 1 | awk '{print $6}')
 		if [ -n "$ip" ]; then
 			cnt=3
 			success=true
@@ -94,10 +94,10 @@ for (( i=0; i<3; i++ ))
 do
         for (( cnt=0; cnt<3; cnt++ ))
 	do
-        	state=$(/usr/local/bin/oc get nodes -o wide | grep master-$i | tail -n 1 | awk '{print $2}')
+		state=$($WORKSPACE/bin/oc get nodes -o wide | grep master-$i | tail -n 1 | awk '{print $2}')
 		if [ "$state" == "Ready" ]; then
 			cnt=3
-			(( master_success=master_success + 1 ))
+			(( master_success = master_success + 1 ))
 		else
 			sleep 10
 		fi
@@ -107,7 +107,7 @@ if [ "$master_success" -eq "3" ]; then
 	echo "Master nodes healthy"
 else
 	echo "ERROR: all master nodes must be ready"
-	oc get nodes
+	$WORKSPACE/bin/oc get nodes
 	exit 1
 fi
 
@@ -130,7 +130,7 @@ for (( i=0; i<$WORKERS; i++ ))
 do
         for (( cnt=0; cnt<3; cnt++ ))
 	do
-        	state=$(/usr/local/bin/oc get nodes -o wide | grep worker-$i | tail -n 1 | awk '{print $2}')
+		state=$($WORKSPACE/bin/oc get nodes -o wide | grep worker-$i | tail -n 1 | awk '{print $2}')
 		if [ "$state" == "Ready" ]; then
 			cnt=3
 			(( worker_success = worker_success + 1 ))
@@ -143,6 +143,6 @@ if [ "$worker_success" -eq "$WORKERS" ]; then
 	echo "Worker nodes healthy"
 else
 	echo "ERROR: all requested worker nodes must be not ready"
-	oc get nodes
+	$WORKSPACE/bin/oc get nodes
 	exit 1
 fi

--- a/scripts/helper/parameters.sh
+++ b/scripts/helper/parameters.sh
@@ -81,3 +81,43 @@ fi
 
 SANITIZED_OCP_VERSION=${OCP_VERSION/./-}
 
+# WORKSPACE is a jenkins environment variable denoting a dedicated execution environment
+# that does not overlap with other jobs.  For this project, there are required input and
+# output files that should be placed outside the git project itself.  If a workspace
+# is not defined, then assume it is the parent directory of the project.
+
+if [ -z "$WORKSPACE" ]; then
+	cdir="$(pwd)"
+	if [[ "$cdir" =~ "ocs-upi-kvm" ]]; then
+		cdirnames=$(echo $cdir | sed 's/\// /g')
+		dir=""
+		for i in $cdirnames
+		do
+			if [ "$i" == "ocs-upi-kvm" ]; then
+				break
+			fi
+			dir="$dir/$i"
+		done
+		WORKSPACE="$dir"
+	elif [ -e ocs-upi-kvm ]; then
+		WORKSPACE="$cdir"
+	else
+		WORKSPACE="$HOME"
+	fi
+fi
+echo WORKSPACE=$WORKSPACE
+
+file_rc=
+function file_present ( ) {
+	file=$1	
+
+	set +e
+	ls_out=$(sudo ls $1 || true)
+	set -e
+
+	if [ -n "$ls_out" ]; then
+		file_rc=0
+	else
+		file_rc=1
+	fi
+}

--- a/scripts/helper/set-passwordless-sudo.sh
+++ b/scripts/helper/set-passwordless-sudo.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Updates the current user's sudo access such that no password
+# is required and thereby eliminating the password prompt. This
+# is a prerequisite for automation scripts that perform privileged
+# operations.  One has to be a privilege user to do it.
+
+me=$(whoami)
+
+echo "$me ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$me
+sudo chmod 640 /etc/sudoers.d/$me

--- a/scripts/helper/setup-kvm-host.sh
+++ b/scripts/helper/setup-kvm-host.sh
@@ -10,9 +10,7 @@
 
 set -xe
 
-TOP_DIR=$(pwd)/..
-
-if [ ! -e $TOP_DIR/files/haproxy.cfg ]; then
+if [ ! -e helper/parameters.sh ]; then
 	echo "Please invoke from the directory ocs-upi-kvm/scripts"
 	exit 1
 fi
@@ -29,7 +27,7 @@ yum -y install powerpc-utils net-tools wget git patch gcc-c++ make
 yum -y module install virt container-tools
 yum -y install libvirt-devel libguestfs libguestfs-tools virt-install ansible haproxy tmux
 
-pushd ~
+pushd $WORKSPACE
 if [ ! -e wipe-2.3.1-17.15.ppc64le.rpm ]; then
 	wget http://rpmfind.net/linux/opensuse/ports/ppc/tumbleweed/repo/oss/ppc64le/wipe-2.3.1-17.15.ppc64le.rpm
 fi
@@ -114,7 +112,7 @@ restorecon /etc/firewalld/services/haproxy-https.xml
 if [ ! -e /etc/haproxy/haproxy.cfg.orig ]; then
 	cp /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.orig
 fi
-cp $TOP_DIR/files/haproxy.cfg /etc/haproxy/haproxy.cfg
+cp $WORKSPACE/ocs-upi-kvm/files/haproxy.cfg /etc/haproxy/haproxy.cfg
 
 chmod 644 /etc/haproxy/haproxy.cfg
 restorecon -Rv /etc/haproxy

--- a/scripts/helper/virsh-cleanup.sh
+++ b/scripts/helper/virsh-cleanup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ ! -e helper/parameters.sh ]; then
+        echo "Please invoke this script from the directory ocs-upi-kvm/scripts"
+        exit 1
+fi
+
+source helper/parameters.sh
+
 # Deactivate VMs
 
 while :
@@ -62,9 +69,8 @@ done
 
 while :
 do
-
 	NET=$(virsh net-list --all | tail -n 2 | head -n 1 | awk '{ print $1 }')
-	if [ "$NET" == "default" ]; then
+	if [[ "$NET" == "default" ]] || [[ "$NET" = \-* ]]; then
 		break;
 	fi
 	echo "virsh net-destroy $NET"
@@ -75,16 +81,15 @@ do
 done
 
 # Recycle libvirtd as it provides dnsmasq 
-systemctl restart libvirtd
-systemctl restart NetworkManager
-firewall-cmd --reload
+sudo systemctl restart libvirtd
+sudo systemctl restart NetworkManager
+sudo firewall-cmd --reload
 
 # Remove files created by add-data-disk.sh
 
-if [ -e ~/.images_path ]; then
-	FILES=$(cat ~/.images_path)
+if [ -e $WORKSPACE/.images_path ]; then
+	FILES=$(cat $WORKSPACE/.images_path)
 	if [ -n "$FILES" ]; then
 		rm -rf $FILES/test-ocp*
 	fi
 fi
-

--- a/scripts/setup-ocs-ci.sh
+++ b/scripts/setup-ocs-ci.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
-user=$(whoami)
-if [ "$user" != root ]; then
-        echo "This script must be invoked as root"
-        exit 1
+set -e
+
+if [ ! -e helper/parameters.sh ]; then
+	echo "This script should be invoked from the directory ocs-upi-kvm/scripts"
+	exit 1
 fi
 
-set -ex
+sudo yum -y install libffi-devel lapack atlas-devel gcc-gfortran openssl-devel gcc-gfortran
+sudo yum -y install python38-devel python38-setuptools python38-Cython python3-virtualenv python3-docutils
 
-TOP_DIR=$(pwd)/..
+source helper/parameters.sh
 
-yum -y install libffi-devel lapack atlas-devel gcc-gfortran openssl-devel gcc-gfortran
-yum -y install python38-devel python38-setuptools python38-Cython python3-virtualenv python3-docutils
+python3.8 -m venv $WORKSPACE/venv
 
-python3.8 -m venv /root/venv
-source /root/venv/bin/activate			# activate named python venv
+source $WORKSPACE/venv/bin/activate		# activate named python venv
 
 pip install --upgrade pip setuptools
 pip install wheel
 
-pushd $TOP_DIR/src/ocs-ci
+pushd ../src/ocs-ci
 pip install -r requirements.txt
 popd
 

--- a/scripts/teardown-ocs-ci.sh
+++ b/scripts/teardown-ocs-ci.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
-user=$(whoami)
-if [ "$user" != root ]; then
-        echo "This script must be invoked as root"
-        exit 1
+set -e
+
+if [ ! -e helper/parameters.sh ]; then
+	echo "This script should be invoked from the directory ocs-upi-kvm/scripts"
+	exit 1
 fi
 
-set -ex
+source helper/parameters.h
 
-TOP_DIR=$(pwd)/..
+export KUBECONFIG=$WORKSPACE/auth/kubeconfig
 
-export KUBECONFIG=~/auth/kubeconfig
+pushd ../src/ocs-ci
 
-source /root/venv/bin/activate                  # enter 'deactivate' in venv shell to exit
+source $WORKSPACE/venv/bin/activate		# enter 'deactivate' in venv shell to exit
 
-pushd $TOP_DIR/src/ocs-ci
+run-ci -m deployment --teardown --ocsci-conf=conf/ocsci/production_powervs_upi.yaml \
+	--cluster-name=ocstest --cluster-path=$WORKSPACE --collect-logs
 
-run-ci -m deployment --teardown --ocsci-conf=conf/ocsci/production_powervs_upi.yaml --cluster-name=ocstest --cluster-path=/root --collect-logs
+deactivate
 
 popd

--- a/scripts/test-ocs-ci.sh
+++ b/scripts/test-ocs-ci.sh
@@ -28,20 +28,27 @@ else
 	fi
 fi
 
-TOP_DIR=$(pwd)/..
+if [ ! -e helper/parameters.sh ]; then
+	echo "This script should be invoked from the directory ocs-upi-kvm/scripts"
+	exit 1
+fi
 
-export KUBECONFIG=~/auth/kubeconfig
+source helper/parameters.sh
 
-source /root/venv/bin/activate                  # enter 'deactivate' in venv shell to exit
+export KUBECONFIG=$WORKSPACE/auth/kubeconfig
 
-pushd $TOP_DIR/src/ocs-ci
+source $WORKSPACE/venv/bin/activate		# enter 'deactivate' in venv shell to exit
+
+pushd ../src/ocs-ci
 
 for i in ${tests[@]}
 do
 	time run-ci -m "tier$i and manage" --ocsci-conf conf/ocsci/production_powervs_upi.yaml \
-       		--cluster-name ocstest --cluster-path /root --collect-logs tests/
+       		--cluster-name ocstest --cluster-path $WORKSPACE --collect-logs tests/
 	rc=$?
 	echo "TEST RESULT: run-ci tier$i rc=$rc" 
 done
 
 deactivate
+
+popd


### PR DESCRIPTION
Sudo capability with passwordless access is required.

The project can be git cloned anywhere, but it should be
noted that the parent directory is assumed to be a workspace
where a lot of files are copied, including log files.  Many
of these files have value that transcend the project which is
just a tool to create a cluster with OCS.  This includes
cluster administration as the oc command and kubeconfig
are copied into the workspace.

Assuming the ocs-upi-kvm project is located at:

~/workspace/ocs-upi-kvm

One would invoke oc like this:

export KUBECONFIG=~/workspace/auth/kubeconfig
~/workspace/bin/oc get nodes

Non-root users must use sudo to see VMs with virsh:

sudo virsh list --all