### PR TITLE
Fix DNS overloading

### DIFF
--- a/scripts/helper/create-cluster.sh
+++ b/scripts/helper/create-cluster.sh
@@ -49,9 +49,6 @@ export PATH=$WORKSPACE/bin:$PATH
 set -e
 
 # Internal variables -- don't change unless you also modify the underlying projects
-
-export BASTION_IP=${BASTION_IP:="192.168.88.2"}
-
 export TERRAFORM_VERSION=${TERRAFORM_VERSION:="v0.13.3"}
 export GO_VERSION=${GO_VERSION:="go1.14.9"}
 

--- a/scripts/helper/parameters.sh
+++ b/scripts/helper/parameters.sh
@@ -88,6 +88,8 @@ fi
 
 ############################## Internal variables & functions ###############################
 
+export BASTION_IP=${BASTION_IP:="192.168.88.2"}
+
 # Sanitize the user specified ocp version which is included in the cluster name.  The cluster
 # name should not include dots (.) as this is reflected in the fully qualified hostname which
 # confuses DHCP.  For example, bastion-test-ocp4.6.tt.testing.  The dot in ocp version is

--- a/scripts/helper/setup-kvm-host.sh
+++ b/scripts/helper/setup-kvm-host.sh
@@ -88,7 +88,7 @@ firewall-cmd --reload
 # Setup the DNS overlay for the cluster
 
 echo -e "[main]\ndns=dnsmasq" | tee /etc/NetworkManager/conf.d/openshift.conf
-echo server=/$CLUSTER_DOMAIN/$CLUSTER_GATEWAY | tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+echo server=/$CLUSTER_DOMAIN/$BASTION_IP | tee /etc/NetworkManager/dnsmasq.d/openshift.conf
 echo dns-forward-max=1000 | tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
 
 systemctl restart NetworkManager


### PR DESCRIPTION
We were running multiple dnsmasq instances on the host, one of which
forwarded requests for the cluster domain to the other, which then
forwarded those requests to named on the bastion. The bastion is also
set up to forward requests to the host, creating a loop. During periods
of high activity, the dnsmasqs were getting overwhelmed, leading to
response times in the 2-5 second range. This change brings us back into
the ~1ms range.

Signed-off-by: Zack Cerza <zack@redhat.com>