### PR TITLE
Automate the invocation kvm-setup-host.sh with codes changes

### DIFF
--- a/scripts/create-ocp.sh
+++ b/scripts/create-ocp.sh
@@ -63,11 +63,23 @@ fi
 
 # Setup kvm on the host
 
+invoke_kvm_setup=false
 if [ ! -e ~/.kvm_setup ]; then
+	invoke_kvm_setup=true
+else
+	source ~/.kvm_setup
+	if [[ -z "$KVM_SETUP_GENCNT_INSTALLED" ]] || [[ "$KVM_SETUP_GENCNT_INSTALLED" -lt "$KVM_SETUP_GENCNT" ]]; then
+		invoke_kvm_setup=true
+	fi
+fi
+
+if [ "$invoke_kvm_setup" == "true" ]; then
 	echo "Invoking setup-kvm-host.sh"
 	sudo -sE helper/setup-kvm-host.sh
-	touch ~/.kvm_setup
+	echo "KVM_SETUP_GENCNT_INSTALLED=$KVM_SETUP_GENCNT" > ~/.kvm_setup
 fi
+
+# Remove pre-existing clusters
 
 if [ "$retry" == false ]; then
 	echo "Invoking virsh-cleanup.sh"

--- a/scripts/helper/parameters.sh
+++ b/scripts/helper/parameters.sh
@@ -90,6 +90,10 @@ fi
 
 export BASTION_IP=${BASTION_IP:="192.168.88.2"}
 
+# Increment this generation count every time that the kvm_setup_host.sh file is changed
+
+export KVM_SETUP_GENCNT=1
+
 # Sanitize the user specified ocp version which is included in the cluster name.  The cluster
 # name should not include dots (.) as this is reflected in the fully qualified hostname which
 # confuses DHCP.  For example, bastion-test-ocp4.6.tt.testing.  The dot in ocp version is

--- a/scripts/helper/setup-kvm-host.sh
+++ b/scripts/helper/setup-kvm-host.sh
@@ -8,6 +8,8 @@
 # along with the cluster domain, so if the underlying projects change
 # this script will have to change as well.
 
+# IMPORTANT: Increment KVM_SETUP_GENCNT if you change code logic in this file
+
 set -e
 
 export WIPE_VERSION=${WIPE_VERSION:=2.3.1-17.15}
@@ -89,7 +91,6 @@ firewall-cmd --reload
 
 echo -e "[main]\ndns=dnsmasq" | tee /etc/NetworkManager/conf.d/openshift.conf
 echo server=/$CLUSTER_DOMAIN/$BASTION_IP | tee /etc/NetworkManager/dnsmasq.d/openshift.conf
-echo dns-forward-max=1000 | tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
 
 systemctl restart NetworkManager
 systemctl restart libvirtd


### PR DESCRIPTION
Implement a generation count for code changes to the script kvm-setup-host.sh
which will be stored in the file ~/.kvm_setup after invoking invoking the
aforementioned setup script.

The generation count serves as a simple version number.  When a cluster is created,
the ~/.kvm_setup file is read to determine the generation count that was evident
when the script was last invoked.  If the installed generation count is less than
or equal to the internal value carried in the source code of the project, then
the setup script should be invoked.

Existing behavior is not impacted.  If the file ~/.kvm_setup doesn't exist, the
setup script is invoked.  If the content of the file is empty, the setup script
is invoked.  In both cases, the file will be generated with a generation count.

If the installed generation count is higher than the internal count, the kvm
setup script will not be invoked.  This would only occur if a downlevel version of
the project was run.  This should not be an issue as the kvm setup process is
assumed to be downward compatible.

Signed-off-by: Luke Browning <lukebrowning@us.ibm.com>