### PR TITLE
virsh-cleanup.sh: Don't remove ocs-ci conf file

### DIFF
--- a/scripts/helper/virsh-cleanup.sh
+++ b/scripts/helper/virsh-cleanup.sh
@@ -77,7 +77,5 @@ fi
 
 echo "Remove ocs-ci supplemental config file"
 
-rm -f $WORKSPACE/ocs-ci-conf.yaml
-
 systemctl restart libvirtd
 systemctl restart firewalld


### PR DESCRIPTION
This line breaks the Jenkins job, and isn't really necessary as the file gets overwritten by https://github.com/ocp-power-automation/ocs-upi-kvm/blob/master/scripts/deploy-ocs-ci.sh#L40