### PR TITLE
Fix ocpdr to get current worker nodes count

### DIFF
--- a/files/ocs-ci/powervs/ocpdr
+++ b/files/ocs-ci/powervs/ocpdr
@@ -18,11 +18,18 @@ popd
 pushd ../$OCP_PROJECT
 
 ARG1=$1
+ARG2=$2
 case "$ARG1" in
 	addnode)
-		export WORKERS=$(( WORKERS + 1 ))
+                number_of_workers=$(oc get nodes | grep "worker" | wc -l)
+                export WORKERS=$(( number_of_workers + $ARG2 ))
 		terraform_apply
 		;;
+        delnode)
+                number_of_workers=$(oc get nodes | grep "worker" | wc -l)
+                export WORKERS=$(( number_of_workers - $ARG2 ))
+                terraform_apply
+                ;;
 	*)
 		echo "ERROR: $0 Invalid argument: arg1=$ARG1"
 		exit 1


### PR DESCRIPTION
ocpdr utility needs to set the new required number of nodes based
on the current count of worker nodes

Signed-off-by: gitsridhar <svenkat@us.ibm.com>