### PR TITLE
Adding manual_subscription_plan_approval.yaml in run-ci for ocs

### DIFF
--- a/samples/dev-ocs.sh
+++ b/samples/dev-ocs.sh
@@ -179,6 +179,7 @@ run-ci -m "tier1" --cluster-name ocstest --cluster-path $WORKSPACE \
 	--ocp-version $OCP_VERSION --ocs-version=$OCS_VERSION \
         --ocsci-conf conf/ocsci/production_powervs_upi.yaml \
 	--ocsci-conf conf/ocsci/lso_enable_rotational_disks.yaml \
+        --ocsci-conf conf/ocsci/manual_subscription_plan_approval.yaml \
         --ocsci-conf $WORKSPACE/ocs-ci-conf.yaml \
         --collect-logs \
         tests/manage/z_cluster/cluster_expansion/test_add_capacity.py 2>&1 | tee $WORKSPACE/test-add-capacity.log

--- a/scripts/deploy-ocs-ci.sh
+++ b/scripts/deploy-ocs-ci.sh
@@ -53,6 +53,7 @@ run-ci -m deployment --deploy \
 	--ocs-version $OCS_VERSION --cluster-name ocstest \
 	--ocsci-conf conf/ocsci/production_powervs_upi.yaml \
 	--ocsci-conf conf/ocsci/lso_enable_rotational_disks.yaml \
+        --ocsci-conf conf/ocsci/manual_subscription_plan_approval.yaml \
 	--ocsci-conf $WORKSPACE/ocs-ci-conf.yaml \
         --cluster-path $WORKSPACE --collect-logs tests/
 

--- a/scripts/test-ocs-ci.sh
+++ b/scripts/test-ocs-ci.sh
@@ -90,6 +90,7 @@ if [[ -n "${tests[@]}" ]]; then
 			--ocp-version $OCP_VERSION --ocs-version=$OCS_VERSION \
 			--ocsci-conf conf/ocsci/production_powervs_upi.yaml \
 			--ocsci-conf conf/ocsci/lso_enable_rotational_disks.yaml \
+                        --ocsci-conf conf/ocsci/manual_subscription_plan_approval.yaml \
 			--ocsci-conf $WORKSPACE/ocs-ci-conf.yaml \
 		        --cluster-path $WORKSPACE --collect-logs \
 			--self-contained-html --junit-xml $LOGDIR/test_results.xml \
@@ -110,6 +111,7 @@ else
 		--ocp-version $OCP_VERSION --ocs-version=$OCS_VERSION \
 		--ocsci-conf conf/ocsci/production_powervs_upi.yaml \
 		--ocsci-conf conf/ocsci/lso_enable_rotational_disks.yaml \
+                --ocsci-conf conf/ocsci/manual_subscription_plan_approval.yaml \
 		--ocsci-conf $WORKSPACE/ocs-ci-conf.yaml \
 		--cluster-path $WORKSPACE --collect-logs \
 		--self-contained-html --junit-xml $LOGDIR/test_results.xml \


### PR DESCRIPTION
This will change the ApprovalStrategy of Subscription from Automatic to Manual which will prevent from causing issues in tier runs as now OCS CSV version is automatically getting upgraded.  

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>