### PR TITLE
Specify a recent commit for helpernode_tag

### DIFF
--- a/files/kvm/site.tfvars.in
+++ b/files/kvm/site.tfvars.in
@@ -29,4 +29,6 @@ dns_forwarders              = "$CLUSTER_GATEWAY;$DNS_BACKUP_SERVER"
 chrony_config               = "$CHRONY_CONFIG"
 chrony_config_servers       = [$CHRONY_CONFIG_SERVERS]
 
+helpernode_tag              = "1ac7f276b537cd734240eda9ed554a254ba80629"
+
 storage_type                = "no"


### PR DESCRIPTION
Since a previous commit removed what we had set, all tests reliant on
`oc rsh` running for longer than 60 seconds are failing. This is because
ocp4-upi-kvm defaults to dd8a076, which is six months old and misses the
haproxy fixes I committed in e185741.

Signed-off-by: Zack Cerza <zack@redhat.com>