### PR TITLE
Skipping one of the scale test

### DIFF
--- a/files/ocs-ci/ocs-ci-04-skipscaletest.patch
+++ b/files/ocs-ci/ocs-ci-04-skipscaletest.patch
@@ -1,0 +1,20 @@
+diff --git a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+index 0183d3c9..0c8cceaa 100644
+--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
++++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+@@ -20,6 +20,7 @@ from ocs_ci.utility.utils import ceph_health_check
+ from ocs_ci.framework.pytest_customization.marks import (
+     skipif_external_mode,
+     skipif_aws_i3,
++    skipif_ibm_power,
+ )
+ 
+ 
+@@ -41,6 +42,7 @@ logger = logging.getLogger(__name__)
+     ],
+ )
+ @skipif_aws_i3
++@skipif_ibm_power
+ class TestScaleOSDsRebootNodes(E2ETest):
+     """
+     Add first set of OSD to a minimum cluster with 50%


### PR DESCRIPTION
This patch will skip one of the scale test as we are not supporting 'add-capacity' feature. 

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>