### PR TITLE
Changing strimzi repo

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -59,7 +59,7 @@ index 623a73ad..781944a3 100644
  # AMQ
  AMQ_NAMESPACE = "myproject"
 -KAFKA_OPERATOR = "https://github.com/strimzi/strimzi-kafka-operator"
-+KAFKA_OPERATOR = "https://github.com/ocp-power-automation/strimzi-kafka-operator"
++KAFKA_OPERATOR = "https://github.com/ocs-power-automation/strimzi-kafka-operator"
  OCS_WORKLOADS = "https://github.com/red-hat-storage/ocs-workloads"
  CODESPEED_URL = "http://10.0.78.167:8000/"
  


### PR DESCRIPTION
Changing strimzi-operator repository to https://github.com/ocs-power-automation/strimzi-kafka-operator
Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>