### PR TITLE
Adding end-to-end script for Upgarde

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,18 +141,20 @@ of the dynamic add storage capability.
 ## Workflow Sample Scripts
 
 ```
-samples/dev-ocs.sh [--retry-ocp] [--latest-ocs] 
+samples/dev-ocs.sh [--retry-ocp] [--latest-ocs]
+samples/dev-ocs-fio.sh [--retry-ocp] [--latest-ocs]
+samples/dev-ocs-perf.sh [--retry-ocp] [--latest-ocs]
 samples/test-ocs.sh [--retry-ocp] [--latest-ocs]
+samples/test-ocs-perf.sh [--retry-ocp] [--latest-ocs]
 ```
 
 These scripts are useful in getting started.  They implement the full sequence of
-high level tasks defined above.  The **test-ocs.sh** invokes **ocs-ci** tier tests
-2, 3, 4, 4a, 4b, and 4c.  Both scripts designate the use of file backed Ceph disks
-which are based on qcow2 files.  These files are sparsely populated enabling the 
-use of servers with as little as 256 GBs of storage, depending on the number of 
-worker nodes that are requested.  The use of file backed data disks is the default.
-The test-ocs scripts include comments showing how physical disk partitions may
-be used instead which may improve performance and resilience.
+high level tasks defined above.  The *dev-ocs* scripts are intended for developer
+use and provide examples of invoking individual ocs-ci tests.  In contrast, the
+*test-ocs* scripts invoke an entire ocs-ci suite.  The **test-ocs.sh** script supports
+tier tests 2, 3, 4, 4a, 4b, and 4c as well as scale and workloads tests.  Dedicated
+scripts are provided for Standalone Fio Testing and Performance, because they have
+external ocs-ci requirements.
 
 As noted above, these scripts may be relocated, customized, and invoked from the
 [workspace directory](https://github.com/lukebrowning/ocs-upi-kvm#workspace-directory)

--- a/files/powervs/env-ocs-ci.sh.in
+++ b/files/powervs/env-ocs-ci.sh.in
@@ -2,3 +2,4 @@ export PLATFORM=powervs
 export OCP_VERSION=$OCP_VERSION
 export OCS_VERSION=$OCS_VERSION
 export OCS_REGISTRY_IMAGE=$OCS_REGISTRY_IMAGE
+export KUBECONFIG=~/auth/kubeconfig

--- a/files/powervs/site.tfvars.in
+++ b/files/powervs/site.tfvars.in
@@ -45,3 +45,5 @@ storage_type                = "no"
 rhcos_kernel_options        = [$RHCOS_KERNEL_ARGS]
 
 setup_snat                  = false
+
+ansible_extra_options       = "-v -e '{\"powervm_rmc\": false}'"

--- a/samples/test-ocs-perf.sh
+++ b/samples/test-ocs-perf.sh
@@ -35,7 +35,8 @@ export PLATFORM=powervs                                         # This must be s
 export OCP_VERSION=${OCP_VERSION:=4.7}                          # 4.5, 4.7, and 4.8 are also supported
 export OCS_VERSION=${OCS_VERSION:=4.7}
 
-export WORKER_DESIRED_CPU=6                                     # ~50 fio pods + ceph on 3 workers
+export WORKERS=4                                                # Extra worker node for elasticsearch
+export WORKER_DESIRED_CPU=6                                     # ~50 fio pods + ceph on 4 workers based on WORKER_VOLUME_SIZE
 export WORKER_DESIRED_MEM=96
 
 # These are optional for KVM OCP cluster create.  Default values are shown
@@ -62,8 +63,9 @@ export WORKER_DESIRED_MEM=96
 #export PVS_ZONE=lon06
 #export SYSTEM_TYPE=s922
 #export PROCESSOR_TYPE=shared
-#export BASTION_IMAGE=rhel-83-02182021
-export WORKER_VOLUME_SIZE=768
+#export BASTION_IMAGE=rhel-83-03192021				# Default is based on OCP_VERSION and USE_TIER1_STORAGE
+#export RHCOS_IMAGE=rhcos-47-02172021				# Default is based on OCP_VERSION and USE_TIER1_STORAGE
+export WORKER_VOLUME_SIZE=1024
 export USE_TIER1_STORAGE=true
 
 # These are optional for PowerVS ocs-ci.  Default values are shown
@@ -119,9 +121,9 @@ function perf_test () {
 		--ocsci-conf conf/ocsci/production_powervs_upi.yaml \
 		--ocsci-conf conf/ocsci/lso_enable_rotational_disks.yaml \
 		--ocsci-conf $WORKSPACE/ocs-ci-conf.yaml \
-		--self-contained-html --junit-xml $LOGDIR/test_results.xml \
-		--html $LOGDIR/$html_fname tests/e2e/performance/test_fio_benchmark.py \
+		--self-contained-html --junit-xml $LOGDIR/test_results.xml --html $LOGDIR/$html_fname \
 		--collect-logs tests/
+
 	rc=$?
 
 	echo -e "\n=> Test result: run-ci performance rc=$rc html=$html_fname"
@@ -257,20 +259,31 @@ set -e
 
 function delete_elasticsearch () {
         echo "Deleting elasticsearch..."
-
 	set +e
 	oc delete deployments.apps/elasticsearch -n elastic
 	oc delete route/elasticsearch -n elastic
 	oc delete service/elasticsearch -n elastic
 	oc delete project/elastic
-	if [ -n "$BASTION_IP" ]; then
-		ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip route del $service_cidr via $master0_ip
-	fi
-
-        exit
+	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip route del $service_cidr
+	set -e
 }
 
-trap delete_elasticsearch SIGINT SIGTERM
+function cleanup_exit () {
+	delete_elastic_search
+	exit
+}
+
+source $WORKSPACE/.bastion_ip
+
+service_cidr=$(oc get networks.config/cluster -o jsonpath='{$.status.serviceNetwork}')
+service_cidr=${service_cidr//\"/}
+service_cidr=${service_cidr/[/}
+service_cidr=${service_cidr/]/}
+
+es_worker_hostname=$(oc get nodes | tail -1 | awk '{print $1}')
+es_worker_ip=$(oc get nodes -o wide | tail -1 | awk '{print $6}')
+
+trap cleanup_exit SIGINT SIGTERM
 
 > $WORKSPACE/perf-ocs-ci.log
 
@@ -278,51 +291,42 @@ set +e
 oc get svc/elasticsearch -n elastic >/dev/null 2>&1
 rc=$?
 set -e
-if [ "$rc" != 0 ]; then
-	echo "Creating elasticsearch pod" | tee -a $WORKSPACE/perf-ocs-ci.log
-	oc new-project elastic
-	oc new-app "discovery.type=single-node" quay.io/piyushgupta1551/elasticsearch:7.11
-	oc expose service/elasticsearch
-	oc status --suggest
-	oc project default
+if [ "$rc" == 0 ]; then
+	delete_elasticsearch | tee -a $WORKSPACE/perf-ocs-ci.log
 fi
+
+echo "Deploy elasticsearch on $es_worker_hostname at $es_worker_ip" | tee -a $WORKSPACE/perf-ocs-ci.log
+
+oc adm new-project elastic --node-selector="kubernetes.io/hostname=$es_worker_hostname"
+oc project elastic
+oc new-app "discovery.type=single-node" quay.io/piyushgupta1551/elasticsearch:7.11
+oc expose service/elasticsearch
+oc project default
+
 oc get service elasticsearch -n elastic | tee -a $WORKSPACE/perf-ocs-ci.log
 
 export ES_CLUSTER_IP=$(oc get service elasticsearch -n elastic | grep ^elasticsearch | awk '{print $3}')
 if [ -z "$ES_CLUSTER_IP" ]; then
 	echo "Elasticsearch is required for this test" | tee -a $WORKSPACE/perf-ocs-ci.log
-	delete_elasticsearch | tee -a $WORKSPACE/perf-ocs-ci.log
 	exit 1
 fi
 
 # The cluster IP is visible only inside the cluster.  Add route to bastion node for the ocp service network
 
-service_cidr=$(oc get networks.config/cluster -o jsonpath='{$.status.serviceNetwork}')
-service_cidr=${service_cidr//\"/}
-service_cidr=${service_cidr/[/}
-service_cidr=${service_cidr/]/}
-node_cidr="192.168.0.0\/24"
-master0_ip=$(oc get node/master-0 -o wide | tail -1 | awk '{print $6}')
-
-source $WORKSPACE/.bastion_ip
+echo "Add route to bastion $BASTION_IP" | tee -a $WORKSPACE/perf-ocs-ci.log
 
 set +e
 
-echo "Add route to bastion $BASTION_IP" | tee -a $WORKSPACE/perf-ocs-ci.log
-
-routes=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip r 2>/dev/null)
-if [[ "$routes" =~ "$service_cidr" ]]; then
-        echo "Delete old route for $service_cidr on bastion" | tee -a $WORKSPACE/perf-ocs-ci.log
-        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip route delete $service_cidr 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
-fi
+node_cidr="192.168.0.0\/24"
 netdev=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip r 2>/dev/null | grep $node_cidr | head -n 1 | awk '{print $3}')
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip route add $service_cidr via $master0_ip dev $netdev onlink 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
+
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ip route add $service_cidr via $es_worker_ip dev $netdev metric 101 onlink 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
 
 echo "Relocate this script to bastion" | tee -a $WORKSPACE/perf-ocs-ci.log
 
 scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $cwdir/$cmd root@$BASTION_IP: 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
 
-echo "Remotely invoking this script on bastion" | tee -a $WORKSPACE/perf-ocs-ci.log
+echo "Remotely invoke this script on bastion" | tee -a $WORKSPACE/perf-ocs-ci.log
 
 cmdname=$(echo $cmd | sed "s|$cmdpath/||")
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP ./$cmdname --run-test 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
@@ -330,6 +334,8 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP
 echo "Get perf logs from bastion" | tee -a $WORKSPACE/perf-ocs-ci.log
 
 scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p -r root@$BASTION_IP:logs-ocs-ci $WORKSPACE 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
+
+set -e
 
 oc get cephcluster --namespace openshift-storage 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log
 oc get pods --namespace openshift-storage 2>&1 | tee -a $WORKSPACE/perf-ocs-ci.log

--- a/samples/upgrade-ocs.sh
+++ b/samples/upgrade-ocs.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# This script may be relocated to the parent directory of ocs-upi-kvm project and
+# edited to invoke a different sequence.  Sometimes to comment a line of execution
+# to avoid recreating the cluster and other times to invoke ocs-ci with different
+# parameters.  This script is relocatable, so the project itself is not modified.
+
+
+# These environment variables are required for all platforms
+
+export PLATFORM=${PLATFORM:="powervs"}				# Also supported: powervs.   Defaults to kvm
+
+#export RHID_USERNAME=<your registered username>		# Change this line or preset in shell
+#export RHID_PASSWORD=<your password>				# Edit or preset
+
+
+# These environment variables are optional for all platforms
+
+export OCP_VERSION=${OCP_VERSION:=4.8}                          # 4.5, 4.6, and 4.7 are also supported
+export OCS_VERSION=${OCS_VERSION:=4.7}
+
+# These are optional for KVM OCP cluster create.  Default values are shown
+
+#export IMAGES_PATH=/var/lib/libvirt/images                     # File system space is important.  Else try /home/libvirt/images
+#export BASTION_IMAGE=rhel-8.2-update-2-ppc64le-kvm.qcow2
+#if [ -z "$DATA_DISK_LIST" ]; then                              # if not set, then file backed disks are used
+#       export DATA_DISK_LIST="sdc1,sdd1,sde1"                  # Each worker node requires a dedicated disk partition
+#       export FORCE_DISK_PARTITION_WIPE=true                   # Default is false
+#fi
+
+
+# These environments variables are required for PowerVS OCP cluster create
+
+#export PVS_API_KEY=<your key>
+#export PVS_SERVICE_INSTANCE_ID=<your instance id>              # Click eye icon on the left of IBM CLoud resource list, copy GUID field
+
+
+# These are optional for PowerVS OCP cluster create.  Default values are shown
+
+#export CLUSTER_ID_PREFIX=$RHID_USERNAME                        # Actually first 3 chars of rhid_username + ocp version
+#export PVS_SUBNET_NAME=ocp-net
+#export PVS_REGION=tok  	                                # Or lon/lon06 sao/sao01 mon/mon01 depending on service instance id
+#export PVS_ZONE=tok04
+#export SYSTEM_TYPE=s922
+#export PROCESSOR_TYPE=shared
+#export BASTION_IMAGE=rhel-83-03192021
+#export WORKER_VOLUME_SIZE=500
+#export USE_TIER1_STORAGE=false
+
+# These environment variables are required for OCS Upgrade 
+
+#export OCS_REGISTRY_IMAGE="quay.io/rhceph-dev/ocs-registry:latest-stable-4.7"       # If you want to upgrade OCS from 4.7.x to 4.7.x+1 then use image tag as latest-stable-4.7.0 or 4.7.1 etc.     
+#export UPGRADE_OCS_VERSION=4.8                                                      # This will upgrade OCS from 4.7 to 4.8 
+#export UPGRADE_OCS_REGISTRY="quay.io/rhceph-dev/ocs-registry:latest-stable-4.8.0"   # OCS  Registry image you want to use for upgrading
+
+# These are optional for PowerVS ocs-ci.  Default values are shown
+
+#export OCS_CI_ON_BASTION=false                                 # When true, ocs-ci runs on bastion node, which may help
+                                                                # with intermittent network issues and testcase timeouts
+
+##############  MAIN ################
+
+set -e
+
+retry_ocp_arg=
+get_latest_ocs=false
+nargs=$#
+i=1
+while (( $i<=$nargs ))
+do
+	arg=$1
+	case "$arg" in
+	--retry-ocp)
+		retry_ocp_arg=--retry
+		shift 1
+		;;
+	--latest-ocs)
+		get_latest_ocs=true
+		shift 1
+		;;
+	*)
+		echo "Usage: $0 [ --retry-ocp ] [ --latest-ocs ]"
+		echo
+		echo "Use --retry when an error occurs while creating the ocp cluster."
+		echo
+		echo "For KVM, if the retry fails, one can destroy the cluster by invoking"
+		echo "the destroy-ocp.sh script.  There is no manual cleanup required."
+		echo
+		echo "For PowerVS, the destroy operation is not always successful as the"
+		echo "create operation may not have gotten far enough to generate build"
+		echo "artifacts identifying the items to be destroyed.  In this case, one"
+		echo "has to destroy the cluster manually using the Cloud GUI."
+		echo
+		echo "Use --latest-ocs to pull the latest commit from the ocsi-ci GH repo."
+		echo
+		echo "See the README for a description of required environment variables."
+		exit 1
+	esac
+	(( i++ ))
+done
+
+if [ -z "$PLATFORM" ] || [ -z "$RHID_USERNAME" ] || [ -z "$RHID_PASSWORD" ]; then
+	echo "Environment variables PLATFORM, RHID_USERNAME, RHID_PASSWORD must be set"
+	exit 1
+fi
+if [ "$PLATFORM" == powervs ]; then
+	if [ -z "$PVS_API_KEY" ] || [ -z "$PVS_SERVICE_INSTANCE_ID" ]; then
+		echo "Environment variables PVS_API_KEY and PVS_SERVICE_INSTANCE_ID must be set for PowerVS"
+		exit 1
+	fi
+	OCP_PROJECT=ocp4-upi-powervs
+else
+	OCP_PROJECT=ocp4-upi-kvm
+fi
+
+
+if [ -z "$WORKSPACE" ]; then
+	cwdir=$(pwd)
+	cmdpath=$(dirname $0)
+	if [ "$cmdpath" == "." ]; then
+		if [ -d ocs-upi-kvm ]; then
+			export WORKSPACE=$cwdir
+		else
+			export WORKSPACE=$cwdir/../..
+		fi
+	elif [[ "$cmdpath" =~ "ocs-upi-kvm/samples" ]]; then
+		export WORKSPACE=$cwdir/$cmdpath/../..
+	elif [[ "$cmdpath" =~ "samples" ]]; then
+		export WORKSPACE=$cwdir/..
+	elif [ -d ocs-upi-kvm ]; then
+		export WORKSPACE=$cwdir
+	else
+		echo "Could not find ocs-upi-kvm directory"
+		exit 1
+	fi
+fi
+
+echo "Location of project: $WORKSPACE/ocs-upi-kvm"
+echo "Location of log files: $WORKSPACE"
+
+pushd $WORKSPACE/ocs-upi-kvm
+
+if [ ! -e src/$OCP_PROJECT/var.tfvars ]; then
+	echo "Refreshing submodule ${OCP_PROJECT}..."
+	git submodule update --init src/$OCP_PROJECT
+fi
+
+if [ ! -e src/ocs-ci/README.md ]; then
+	echo "Refreshing submodule ocs-ci..."
+	git submodule update --init src/ocs-ci
+fi
+
+if [ "$get_latest_ocs" == true ]; then
+	echo "Getting latest ocs-ci..."
+	pushd $WORKSPACE/ocs-upi-kvm/src/ocs-ci
+	git checkout master
+	git pull
+	popd
+fi
+
+echo "Invoking scripts..."
+
+pushd $WORKSPACE/ocs-upi-kvm/scripts
+
+set -o pipefail
+
+./create-ocp.sh $retry_ocp_arg 2>&1 | tee $WORKSPACE/create-ocp.log
+
+source $WORKSPACE/env-ocp.sh
+oc get nodes 2>&1 | tee -a $WORKSPACE/create-ocp.log
+
+./setup-ocs-ci.sh 2>&1 | tee $WORKSPACE/setup-ocs-ci.log
+
+set +e
+./deploy-ocs-ci.sh 2>&1 | tee $WORKSPACE/deploy-ocs-ci.log
+
+echo -e "\n CSV version...\n" | tee -a $WORKSPACE/deploy-ocs-ci.log 
+oc get csv -n openshift-storage 2>&1 | tee -a $WORKSPACE/deploy-ocs-ci.log
+
+echo -e "\n Pods in openshift-storage namespace...\n" | tee -a $WORKSPACE/deploy-ocs-ci.log
+oc get pods -n openshift-storage 2>&1 | tee -a $WORKSPACE/deploy-ocs-ci.log
+
+echo -e "\n Ceph Status...\n" | tee -a $WORKSPACE/deploy-ocs-ci.log
+TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
+oc rsh -n openshift-storage $TOOLS_POD ceph -s 2>&1 | tee -a $WORKSPACE/deploy-ocs-ci.log 
+
+CEPH_STATE=$(oc get cephcluster --namespace openshift-storage | tee -a $WORKSPACE/deploy-ocs-ci.log)
+
+if [[ ! "$CEPH_STATE" =~ HEALTH_OK ]]; then
+	echo "ERROR: Failed CEPH Health Check" | tee -a $WORKSPACE/deploy-ocs-ci.log
+	exit 1
+fi
+set -e
+
+echo -e "\n Upgrading..."
+
+./upgrade-ocs-ci.sh 2>&1 | tee $WORKSPACE/upgrade-ocs-ci.log
+
+CEPH_STATE=$(oc get cephcluster --namespace openshift-storage | tee -a $WORKSPACE/upgrade-ocs-ci.log)
+
+if [[ ! "$CEPH_STATE" =~ HEALTH_OK ]]; then
+        echo "ERROR: Failed CEPH Health Check" | tee -a $WORKSPACE/upgrade-ocs-ci.log
+        exit 1
+fi
+
+
+echo -e "\n Running tier1 test suite..."
+
+./test-ocs-ci.sh --tier 1 2>&1 | tee $WORKSPACE/test-ocs-ci-tier1.log
+
+echo -e "\n Checking Ceph Status again...\n" | tee -a $WORKSPACE/test-ocs-ci-tier1.log
+
+TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
+oc rsh -n openshift-storage $TOOLS_POD ceph -s 2>&1 | tee -a $WORKSPACE/test-ocs-ci-tier1.log
+
+echo -e "\n Destroying OCP cluster..."
+
+./destroy-ocp.sh 2>&1 | tee $WORKSPACE/destroy-ocp.log
+
+if [ "$?" != 0 ] && [ "$PLATFORM" == powervs ]; then
+        echo "ERROR: cluster destroy failed.  Use cloud GUI to remove virtual instances"
+fi

--- a/scripts/helper/powervs/parameters.sh
+++ b/scripts/helper/powervs/parameters.sh
@@ -136,6 +136,8 @@ function prepare_new_cluster_delete_old_cluster () {
 	./destroy-ocp.sh
 }
 
+# This is invoked at the end of ocp cluster create
+
 function setup_remote_oc_use () {
 	pushd $WORKSPACE/ocs-upi-kvm/src/$OCP_PROJECT
 
@@ -179,6 +181,8 @@ function setup_remote_oc_use () {
 	popd
 }
 
+# This is invoked at the start of setup-ocs-ci.sh
+
 function setup_remote_ocsci_use () {
 	source $WORKSPACE/.bastion_ip
 
@@ -196,14 +200,14 @@ function setup_remote_ocsci_use () {
 		BASTION_CMD="cp -r openstack-upi/auth ~"
 		ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP $BASTION_CMD >/dev/null 2>&1
 
-		echo "Copy ocs-ci code with development patches to bastion node $BASTION_IP"
+		echo "Copy ocs-upi-kvm to bastion node $BASTION_IP"
 
 		pushd $WORKSPACE
-		tar -zcvf bastion-ocs-upi-ci.tar.gz ocs-upi-kvm >/dev/null 2>&1
+		tar -zcvf bastion-ocs-upi-kvm.tar.gz ocs-upi-kvm >/dev/null 2>&1
 		popd
 		ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP rm -rf ocs-upi-kvm >/dev/null 2>&1
-		scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $WORKSPACE/bastion-ocs-upi-ci.tar.gz root@$BASTION_IP: >/dev/null 2>&1
-		BASTION_CMD="tar -xvzf bastion-ocs-upi-ci.tar.gz >/dev/null 2>&1"
+		scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $WORKSPACE/bastion-ocs-upi-kvm.tar.gz root@$BASTION_IP: >/dev/null 2>&1
+		BASTION_CMD="tar -xvzf bastion-ocs-upi-kvm.tar.gz >/dev/null 2>&1"
 		ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP $BASTION_CMD >/dev/null 2>&1
 		ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$BASTION_IP chown -R root:root ocs-upi-kvm >/dev/null 2>&1
 	fi


### PR DESCRIPTION
This script will perform end to end steps required for Upgrading OCS. It will do the following : 
-  create OCP cluster, 
-  run `setup-ocs-ci.sh` for installing packages and venv, 
-  deploy OCS , 
-  upgrade OCS 
-  run tier1 test on upgraded cluster
-  and in the end it will delete the OCP cluster. 
Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>