### PR TITLE
Objct storage and service patches

### DIFF
--- a/files/ocs-ci/ocs-ci-08-objectstorage.patch
+++ b/files/ocs-ci/ocs-ci-08-objectstorage.patch
@@ -1,0 +1,163 @@
+diff --git a/tests/manage/mcg/test_bucket_deletion.py b/tests/manage/mcg/test_bucket_deletion.py
+index 7edf9074..ddad1aa7 100644
+--- a/tests/manage/mcg/test_bucket_deletion.py
++++ b/tests/manage/mcg/test_bucket_deletion.py
+@@ -172,8 +172,16 @@ class TestBucketDeletion(MCGTest):
+                 *["OC", {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}}],
+                 marks=[tier1],
+             ),
++            pytest.param(
++                *["OC", {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}}],
++                marks=[tier1],
++            ),
++            pytest.param(
++                *["CLI", {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}}],
++                marks=[tier1],
++            ),
+         ],
+-        ids=["S3", "CLI", "OC", "OC-AWS", "OC-AZURE", "OC-GCP"],
++        ids=["S3", "CLI", "OC", "OC-AWS", "OC-AZURE", "OC-GCP", "OC-IBMCOS", "CLI-IBMCOS"],
+     )
+     def test_bucket_delete_with_objects(
+         self, mcg_obj, awscli_pod, bucket_factory, interface, bucketclass_dict
+diff --git a/tests/manage/mcg/test_multicloud.py b/tests/manage/mcg/test_multicloud.py
+index ffc8f970..9c4bdddf 100644
+--- a/tests/manage/mcg/test_multicloud.py
++++ b/tests/manage/mcg/test_multicloud.py
+@@ -25,6 +25,8 @@ class TestMultiCloud(MCGTest):
+             pytest.param(("oc", {"azure": [(1, None)]})),
+             pytest.param(("cli", {"gcp": [(1, None)]})),
+             pytest.param(("oc", {"gcp": [(1, None)]})),
++            pytest.param(("cli", {"ibmcos": [(1, None)]})),
++            pytest.param(("oc", {"ibmcos": [(1, None)]})),
+         ],
+         # A test ID list for describing the parametrized tests
+         # <CLOUD_PROVIDER>-<METHOD>-<AMOUNT-OF-BACKINGSTORES>
+@@ -35,6 +37,8 @@ class TestMultiCloud(MCGTest):
+             "AZURE-OC-1",
+             "GCP-CLI-1",
+             "GCP-OC-1",
++            "IBMCOS-CLI-1",
++            "IBMCOS-OC-1",
+         ],
+     )
+     def test_multicloud_backingstore_creation(
+@@ -56,6 +60,8 @@ class TestMultiCloud(MCGTest):
+             pytest.param(("oc", {"azure": [(1, None)]})),
+             pytest.param(("cli", {"gcp": [(1, None)]})),
+             pytest.param(("oc", {"gcp": [(1, None)]})),
++            pytest.param(("cli", {"ibmcos": [(1, None)]})),
++            pytest.param(("oc", {"ibmcos": [(1, None)]})),
+         ],
+         # A test ID list for describing the parametrized tests
+         # <CLOUD_PROVIDER>-<METHOD>-<AMOUNT-OF-BACKINGSTORES>
+@@ -66,6 +72,8 @@ class TestMultiCloud(MCGTest):
+             "AZURE-OC-1",
+             "GCP-CLI-1",
+             "GCP-OC-1",
++            "IBMCOS-CLI-1",
++            "IBMCOS-OC-1",
+         ],
+     )
+     def test_multicloud_backingstore_deletion(
+diff --git a/tests/manage/mcg/test_object_integrity.py b/tests/manage/mcg/test_object_integrity.py
+index d7bf0213..b16e0829 100644
+--- a/tests/manage/mcg/test_object_integrity.py
++++ b/tests/manage/mcg/test_object_integrity.py
+@@ -53,6 +53,14 @@ class TestObjectIntegrity(MCGTest):
+                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
+                 marks=[tier1],
+             ),
++            pytest.param(
++                {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
++                marks=[tier1],
++            ),
++            pytest.param(
++                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
++                marks=[tier1],
++            ),
+             pytest.param(
+                 {
+                     "interface": "OC",
+@@ -77,6 +85,8 @@ class TestObjectIntegrity(MCGTest):
+             "AWS-OC-1",
+             "AZURE-OC-1",
+             "GCP-OC-1",
++            "IBMCOS-OC-1",
++            "IBMCOS-CLI-1",
+             "AWS-OC-Cache",
+         ],
+     )
+diff --git a/tests/manage/mcg/test_write_to_bucket.py b/tests/manage/mcg/test_write_to_bucket.py
+index 923e7ca0..b7138501 100644
+--- a/tests/manage/mcg/test_write_to_bucket.py
++++ b/tests/manage/mcg/test_write_to_bucket.py
+@@ -80,12 +80,22 @@ class TestBucketIO(MCGTest):
+                 *["OC", {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}}],
+                 marks=[tier1],
+             ),
++            pytest.param(
++                *["OC", {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}}],
++                marks=[tier1],
++            ),
++            pytest.param(
++                *["CLI", {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}}],
++                marks=[tier1],
++            ),
+         ],
+         ids=[
+             "DEFAULT-BACKINGSTORE",
+             "AWS-OC-1",
+             "AZURE-OC-1",
+             "GCP-OC-1",
++            "IBMCOS-OC-1",
++            "IBMCOS-CLI-1",
+         ],
+     )
+     def test_write_file_to_bucket(
+@@ -138,12 +148,22 @@ class TestBucketIO(MCGTest):
+                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
+                 marks=[tier1],
+             ),
++            pytest.param(
++                {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
++                marks=[tier1],
++            ),
++            pytest.param(
++                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
++                marks=[tier1],
++            ),
+         ],
+         ids=[
+             "DEFAULT-BACKINGSTORE",
+             "AWS-OC-1",
+             "AZURE-OC-1",
+             "GCP-OC-1",
++            "IBMCOS-OC-1",
++            "IBMCOS-CLI-1",
+         ],
+     )
+     def test_mcg_data_deduplication(
+@@ -202,12 +222,22 @@ class TestBucketIO(MCGTest):
+                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
+                 marks=[tier1],
+             ),
++            pytest.param(
++                {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
++                marks=[tier1],
++            ),
++            pytest.param(
++                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
++                marks=[tier1],
++            ),
+         ],
+         ids=[
+             "DEFAULT-BACKINGSTORE",
+             "AWS-OC-1",
+             "AZURE-OC-1",
+             "GCP-OC-1",
++            "IBMCOS-OC-1",
++            "IBMCOS-CLI-1",
+         ],
+     )
+     def test_mcg_data_compression(

--- a/files/ocs-ci/ocs-ci-09-serviceformat.patch
+++ b/files/ocs-ci/ocs-ci-09-serviceformat.patch
@@ -1,0 +1,77 @@
+diff --git a/ocs_ci/utility/service.py b/ocs_ci/utility/service.py
+index 5ae12072..d2132d7a 100644
+--- a/ocs_ci/utility/service.py
++++ b/ocs_ci/utility/service.py
+@@ -54,7 +54,7 @@ class Service(object):
+         nodeip = self.nodes[node.name]
+         result = exec_cmd(
+             f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{self.bastion_ip} ssh core@{nodeip} "
+-            "sudo systemctl is-active {self.service_name}.service",
++            f"sudo systemctl is-active {self.service_name}.service",
+             ignore_error=True,
+         )
+ 
+@@ -86,7 +86,7 @@ class Service(object):
+         nodeip = self.nodes[node.name]
+         cmd = (
+             f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{self.bastion_ip} ssh core@{nodeip} "
+-            "sudo systemctl stop {self.service_name}.service"
++            f"sudo systemctl stop {self.service_name}.service"
+         )
+         if self.force:
+             cmd += " -f"
+@@ -103,7 +103,7 @@ class Service(object):
+         )
+         if not ret.wait_for_func_status(result=True):
+             raise UnexpectedBehaviour(
+-                "Service {self.service_name} on Node {node.name} is still Running"
++                f"Service {self.service_name} on Node {node.name} is still Running"
+             )
+ 
+     def start(self, node, timeout):
+@@ -120,7 +120,7 @@ class Service(object):
+         nodeip = self.nodes[node.name]
+         cmd = (
+             f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{self.bastion_ip} ssh core@{nodeip} "
+-            "sudo systemctl start {self.service_name}.service"
++            f"sudo systemctl start {self.service_name}.service"
+         )
+         result = exec_cmd(cmd)
+         logger.info(f"Result of start of service {self.service_name} is {result}")
+@@ -133,7 +133,7 @@ class Service(object):
+         )
+         if not ret.wait_for_func_status(result=True):
+             raise UnexpectedBehaviour(
+-                "Service {self.service_name} on Node {node.name} is still not Running"
++                f"Service {self.service_name} on Node {node.name} is still not Running"
+             )
+ 
+     def kill(self, node, timeout):
+@@ -148,7 +148,7 @@ class Service(object):
+         nodeip = self.nodes[node.name]
+         cmd = (
+             f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{self.bastion_ip} ssh core@{nodeip} "
+-            "sudo systemctl kill {self.service_name}.service"
++            f"sudo systemctl kill {self.service_name}.service"
+         )
+         result = exec_cmd(cmd)
+         ret = TimeoutSampler(
+@@ -172,7 +172,7 @@ class Service(object):
+         nodeip = self.nodes[node.name]
+         cmd = (
+             f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{self.bastion_ip} ssh core@{nodeip} "
+-            "sudo systemctl restart {self.service_name}.service"
++            f"sudo systemctl restart {self.service_name}.service"
+         )
+         result = exec_cmd(cmd)
+         ret = TimeoutSampler(
+@@ -200,7 +200,7 @@ class Service(object):
+         nodeip = self.nodes[node.name]
+         cmd = (
+             f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{self.bastion_ip} ssh core@{nodeip} "
+-            "sudo systemctl status {self.service_name}.service"
++            f"sudo systemctl status {self.service_name}.service"
+         )
+         result = exec_cmd(cmd)
+         logger.info(f"Result of status of service {self.service_name} is {result}")
+


### PR DESCRIPTION
This commit includes changes to mcg test cases for IBM COS object storage.
It also includes changes to service module with format changes.

Signed-off-by: gitsridhar <svenkat@us.ibm.com>

From setup-ocs-ci run:

atchfiles=../../files/ocs-ci/ocs-ci-00-ripsaw.patch ../../files/ocs-ci/ocs-ci-01-strimzi.patch ../../files/ocs-ci/ocs-ci-02-skip4xtest.patch ../../files/ocs-ci/ocs-ci-03-skipscaletest.patch ../../files/ocs-ci/ocs-ci-04-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-05-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-06-cpulimits.patch ../../files/ocs-ci/ocs-ci-07-optionaloperators.patch ../../files/ocs-ci/ocs-ci-08-objectstorage.patch ../../files/ocs-ci/ocs-ci-09-service.patch
ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /home/test/objwork12/ocs-ci.patch from /home/test/objwork12/ocs-upi-kvm/files/ocs-ci/
checking file tests/e2e/performance/test_fio_benchmark.py
checking file ocs_ci/ocs/ripsaw.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/ocs/constants.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
checking file tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/deployment/helpers/lso_helpers.py
checking file tests/manage/mcg/test_bucket_deletion.py
checking file tests/manage/mcg/test_multicloud.py
checking file tests/manage/mcg/test_object_integrity.py
checking file tests/manage/mcg/test_write_to_bucket.py
checking file ocs_ci/utility/service.py
Patching ocs-ci...
patching file tests/e2e/performance/test_fio_benchmark.py
patching file ocs_ci/ocs/ripsaw.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/ocs/constants.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
patching file tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/deployment/helpers/lso_helpers.py
patching file tests/manage/mcg/test_bucket_deletion.py
patching file tests/manage/mcg/test_multicloud.py
patching file tests/manage/mcg/test_object_integrity.py
patching file tests/manage/mcg/test_write_to_bucket.py
patching file ocs_ci/utility/service.py
