### PR TITLE
undefine storage pool if status is inactive

### DIFF
--- a/scripts/helper/kvm/virsh-cleanup.sh
+++ b/scripts/helper/kvm/virsh-cleanup.sh
@@ -22,6 +22,12 @@ declare -i nvols
 pools=$(virsh pool-list --all | grep test-ocp | awk '{print $1}')
 for i in $pools
 do
+	pool_status=$(virsh pool-info $i | grep State | awk '{ print $2 }')
+	if [[ "$pool_status" == "inactive" ]]; then
+		echo "virsh pool-undefine $i"
+		virsh pool-undefine $i
+	fi
+
 	nvols=$(virsh vol-list $i | wc -l)-3
 	while :
 	do

--- a/scripts/helper/kvm/virsh-cleanup.sh
+++ b/scripts/helper/kvm/virsh-cleanup.sh
@@ -23,29 +23,26 @@ pools=$(virsh pool-list --all | grep test-ocp | awk '{print $1}')
 for i in $pools
 do
 	pool_status=$(virsh pool-info $i | grep State | awk '{ print $2 }')
-	if [[ "$pool_status" == "inactive" ]]; then
-		echo "virsh pool-undefine $i"
-		virsh pool-undefine $i
+	if [[ "$pool_status" != "inactive" ]]; then
+		nvols=$(virsh vol-list $i | wc -l)-3
+		while :
+		do
+			if (( nvols < 1 )); then
+				break;
+			fi
+			vol=$(virsh vol-list $i | tail -n 2 | head -n 1 | awk '{ print $1 }')
+
+			echo "virsh vol-delete $vol --pool $i"
+			virsh vol-delete $vol --pool $i
+
+			nvols=nvols-1
+		done
+		echo "virsh pool-destroy $i"
+		virsh pool-destroy $i
+
+		echo "virsh pool-delete $i"
+		virsh pool-delete $i >/dev/null 2>&1
 	fi
-
-	nvols=$(virsh vol-list $i | wc -l)-3
-	while :
-	do
-		if (( nvols < 1 )); then
-			break;
-		fi
-		vol=$(virsh vol-list $i | tail -n 2 | head -n 1 | awk '{ print $1 }')
-
-		echo "virsh vol-delete $vol --pool $i"
-		virsh vol-delete $vol --pool $i
-
-		nvols=nvols-1
-	done
-	echo "virsh pool-destroy $i"
-	virsh pool-destroy $i
-
-	echo "virsh pool-delete $i"
-	virsh pool-delete $i >/dev/null 2>&1
 
 	echo "virsh pool-undefine $i"
 	virsh pool-undefine $i


### PR DESCRIPTION
The steps in "Delete storage volumes" loop requires the storage pool to be active. Added code to check for status, and if the pool is inactive, go ahead with deletion.