### PR TITLE
Add patch to help oc drain to work

### DIFF
--- a/files/ocs-ci/ocs-ci-10-drain.patch
+++ b/files/ocs-ci/ocs-ci-10-drain.patch
@@ -1,0 +1,13 @@
+diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
+index b30171f4..a6e397a4 100644
+--- a/ocs_ci/ocs/node.py
++++ b/ocs_ci/ocs/node.py
+@@ -195,7 +195,7 @@ def drain_nodes(node_names):
+     try:
+         ocp.exec_oc_cmd(
+             f"adm drain {node_names_str} --force=true --ignore-daemonsets "
+-            f"--delete-local-data",
++            f"--delete-local-data --timeout=1810s",
+             timeout=1800,
+         )
+     except TimeoutExpired:


### PR DESCRIPTION
This patch adds --timeout=1810s to oc adm drain command
Without this change, ocs-ci/run-ci crashes while executing
drain command.

Signed-off-by: gitsridhar <svenkat@us.ibm.com>