### PR TITLE
Use strimzi-kafka-operator master branch

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -1,5 +1,5 @@
 diff --git a/ocs_ci/ocs/amq.py b/ocs_ci/ocs/amq.py
-index bdb88deb..26d8ef64 100644
+index bdb88deb..97374463 100644
 --- a/ocs_ci/ocs/amq.py
 +++ b/ocs_ci/ocs/amq.py
 @@ -25,7 +25,7 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check, validate_pv
@@ -11,16 +11,26 @@ index bdb88deb..26d8ef64 100644
  AMQ_BENCHMARK_NAMESPACE = "tiller"
 
 
-@@ -47,7 +47,7 @@ class AMQ(object):
-         """
-         self.args = kwargs
-         self.repo = self.args.get("repo", constants.KAFKA_OPERATOR)
--        self.branch = self.args.get("branch", "master")
-+        self.branch = self.args.get("branch", "ibm-ppc64le")
-         self.ocp = OCP()
-         self.ns_obj = OCP(kind="namespace")
-         self.pod_obj = OCP(kind="pod")
-@@ -610,9 +610,9 @@ class AMQ(object):
+@@ -74,6 +74,18 @@ class AMQ(object):
+             git_clone_cmd = f"git clone {self.repo} "
+             run(git_clone_cmd, shell=True, cwd=self.dir, check=True)
+             self.amq_dir = "strimzi-kafka-operator/packaging/install/cluster-operator/"
++
++            self.sed_dir = os.path.join(self.dir, self.amq_dir)
++            log.info(f"Patching 060-Deployment-strimzi-cluster-operator.yaml for ppc64le images in {self.amq_dir}")
++            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-2.8.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-2.8.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-2.7.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-2.7.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-2.7.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-2.7.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++
++            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.20.1|quay.io/multi-arch/strimzi-kafka-bridge:0.19.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/jmxtrans:latest|quay.io/aaruniaggarwal/strimzi-jmxtrans:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kaniko-executor:latest|quay.io/aaruniaggarwal/kaniko-executor:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++
+             self.amq_kafka_pers_yaml = (
+                 "strimzi-kafka-operator/packaging/examples/kafka/kafka-persistent.yaml"
+             )
+@@ -610,9 +622,9 @@ class AMQ(object):
          # Install helm cli (version v2.16.0 as we need tiller component)
          # And create tiller pods
          wget_cmd = f"wget -c --read-timeout=5 --tries=0 {URL}"
@@ -32,7 +42,7 @@ index bdb88deb..26d8ef64 100644
              f" --service-account {tiller_namespace}"
          )
          exec_cmd(cmd=wget_cmd, cwd=self.dir)
-@@ -634,7 +634,7 @@ class AMQ(object):
+@@ -634,7 +646,7 @@ class AMQ(object):
          values = templating.load_yaml(constants.AMQ_BENCHMARK_VALUE_YAML)
          values["numWorkers"] = num_of_clients
          benchmark_cmd = (
@@ -41,7 +51,7 @@ index bdb88deb..26d8ef64 100644
              f" --name {benchmark_pod_name} --tiller-namespace {tiller_namespace}"
          )
          exec_cmd(cmd=benchmark_cmd, cwd=self.dir)
-@@ -980,7 +980,7 @@ class AMQ(object):
+@@ -980,7 +992,7 @@ class AMQ(object):
          if self.benchmark:
              # Delete the helm app
              try:
@@ -50,19 +60,6 @@ index bdb88deb..26d8ef64 100644
                  run(purge_cmd, shell=True, cwd=self.dir, check=True)
              except (CommandFailed, CalledProcessError) as cf:
                  log.error("Failed to delete help app")
-diff --git a/ocs_ci/ocs/constants.py b/ocs_ci/ocs/constants.py
-index 4a1af104..5078feea 100644
---- a/ocs_ci/ocs/constants.py
-+++ b/ocs_ci/ocs/constants.py
-@@ -179,7 +179,7 @@ OCS_MONKEY_REPOSITORY = "https://github.com/red-hat-storage/ocs-monkey.git"
-
- # AMQ
- AMQ_NAMESPACE = "myproject"
--KAFKA_OPERATOR = "https://github.com/strimzi/strimzi-kafka-operator"
-+KAFKA_OPERATOR = "https://github.com/ocs-power-automation/strimzi-kafka-operator"
- RGW_KAFKA_NOTIFY = "https://github.com/shonpaz123/notify/"
- OCS_WORKLOADS = "https://github.com/red-hat-storage/ocs-workloads"
- CODESPEED_URL = "http://10.0.78.167:8000/"
 diff --git a/ocs_ci/templates/workloads/amq/benchmark/values.yaml b/ocs_ci/templates/workloads/amq/benchmark/values.yaml
 index fafa213c..9ae81dda 100644
 --- a/ocs_ci/templates/workloads/amq/benchmark/values.yaml


### PR DESCRIPTION
PR includes following changes:
- Eliminate use of cloned repo and use the strimzi-kafka-operator's master branch as per ocs-ci. 
- Use ppc64le-based built images for Strimzi