### PR TITLE
pass monitoring.yaml during deployment

### DIFF
--- a/scripts/deploy-ocs-ci.sh
+++ b/scripts/deploy-ocs-ci.sh
@@ -62,6 +62,7 @@ run-ci -m deployment --deploy \
 	--ocsci-conf conf/ocsci/production_powervs_upi.yaml \
 	--ocsci-conf conf/ocsci/lso_enable_rotational_disks.yaml \
 	--ocsci-conf conf/ocsci/manual_subscription_plan_approval.yaml \
+	--ocsci-conf conf/examples/monitoring.yaml \
 	--ocsci-conf $WORKSPACE/ocs-ci-conf.yaml \
         --cluster-path $WORKSPACE --collect-logs tests/
 


### PR DESCRIPTION
`monitoring_enabled` and `persistent-monitoring` parameters need to be enabled during deployment for running prometheus tests. It creates the configmap cluster-monitoring-config with reconfigured storage class.