### PR TITLE
Add patch for missing SC fix and rebase ocs-ci

### DIFF
--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,0 +1,17 @@
+diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
+index 672f07f7..8476469b 100644
+--- a/ocs_ci/deployment/deployment.py
++++ b/ocs_ci/deployment/deployment.py
+@@ -1104,6 +1104,12 @@ def setup_persistent_monitoring():
+     """
+     Change monitoring backend to OCS
+     """
++
++    # Validate the storage class exists
++    retry((CommandFailed), tries=16, delay=15)(
++        helpers.default_storage_class
++    )(interface_type=constants.CEPHBLOCKPOOL)
++
+     sc = helpers.default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
+
+     # Get the list of monitoring pods


### PR DESCRIPTION
setup-ocs-ci.sh script execution results:

```
Nothing to do.
Complete!
~/sc-fix/ocs-upi-kvm/src/ocs-ci ~/sc-fix/ocs-upi-kvm/scripts
patchfiles=../../files/ocs-ci/ocs-ci-00-ripsaw.patch ../../files/ocs-ci/ocs-ci-01-strimzi.patch ../../files/ocs-ci/ocs-ci-02-skipscaletest.patch ../../files/ocs-ci/ocs-ci-03-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-04-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-05-drain.patch ../../files/ocs-ci/ocs-ci-06-check-sc-exists.patch
ls: cannot access '../../files/ocs-ci/powervs/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /home/aditi/sc-fix/ocs-ci.patch from /home/aditi/sc-fix/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/ripsaw.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
Patching ocs-ci...
patching file ocs_ci/ocs/ripsaw.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
Collecting pip
```