### PR TITLE
Correcting strimzi patch for kafka-bridge image

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -23,7 +23,7 @@ index bdb88deb..97374463 100644
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-2.7.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-2.7.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +
 +            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.20.1|quay.io/multi-arch/strimzi-kafka-bridge:0.19.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.20.2|quay.io/multi-arch/strimzi-kafka-bridge:0.19.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/jmxtrans:latest|quay.io/aaruniaggarwal/strimzi-jmxtrans:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kaniko-executor:latest|quay.io/aaruniaggarwal/kaniko-executor:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +


### PR DESCRIPTION
Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>

Strimzi repository has updated using kafka-bridge image from quay.io/strimzi/kafka-bridge:0.20.1 to quay.io/strimzi/kafka-bridge:0.20.2 (https://github.com/strimzi/strimzi-kafka-operator/blob/main/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml#L85)
due to which our patch is not getting applied for kafka-bridge image and pod is failing with CrashLoopBackOff error as image is x86 only (quay.io/strimzi/kafka-bridge:0.20.2) . 