### PR TITLE
ocs-ci rebase

### DIFF
--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -71,24 +71,18 @@ index 36b5a124..2ee02469 100644
      """
      Test add capacity when one of the resources gets deleted
 diff --git a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
-index cb5b667c..1f0d8e1b 100644
+index c5fed9a2..871c59ad 100644
 --- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
 +++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
-@@ -1,8 +1,12 @@
- import logging
- 
-+from ocs_ci.framework.pytest_customization.marks import (
-+    skipif_openshift_dedicated,
+@@ -5,6 +5,7 @@ from ocs_ci.ocs.cluster import CephCluster
+ from ocs_ci.framework.pytest_customization.marks import (
+     skipif_openshift_dedicated,
+     skipif_flexy_deployment,
 +    skipif_ibm_power,
-+)
-+
- from ocs_ci.framework.testlib import tier1, ignore_leftovers, ManageTest
- from ocs_ci.ocs.cluster import CephCluster
--from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
- 
+ )
+
  logger = logging.getLogger(__name__)
- 
-@@ -10,6 +14,7 @@ logger = logging.getLogger(__name__)
+@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
  @skipif_openshift_dedicated
  @ignore_leftovers
  @tier1
@@ -97,22 +91,24 @@ index cb5b667c..1f0d8e1b 100644
      """
      Automates adding worker nodes to the cluster while IOs
 diff --git a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
-index 8f452b4b..eeadbb51 100644
+index 6816f903..1c4765f7 100644
 --- a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
 +++ b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
-@@ -1,6 +1,11 @@
+@@ -1,8 +1,12 @@
  import logging
  import pytest
- 
+
 +from ocs_ci.framework.pytest_customization.marks import (
-+    skipif_ibm_power,
++   skipif_flexy_deployment,
++   skipif_ibm_power,
 +)
 +
-+
  from ocs_ci.ocs import constants
+-from ocs_ci.framework.pytest_customization.marks import skipif_flexy_deployment
  from ocs_ci.framework.testlib import tier1, ManageTest
  from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
-@@ -12,6 +17,7 @@ logger = logging.getLogger(__name__)
+ from ocs_ci.ocs.resources.pod import get_pod_node, get_plugin_pods
+@@ -15,6 +19,7 @@ logger = logging.getLogger(__name__)
  @tier1
  @pytest.mark.polarion_id("OCS-2490")
  @pytest.mark.bugzilla("1794389")

--- a/files/ocs-ci/ocs-ci-04-skip-memoryleak.patch
+++ b/files/ocs-ci/ocs-ci-04-skip-memoryleak.patch
@@ -1,20 +1,21 @@
 diff --git a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
-index 267d68ce..ba868fe1 100644
+index 374c95f2..f49ac7eb 100644
 --- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
 +++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
-@@ -14,7 +14,10 @@ from ocs_ci.ocs import constants
+@@ -14,7 +14,11 @@ from ocs_ci.ocs import constants
  from ocs_ci.ocs.resources import pod
  from ocs_ci.utility import utils
  from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 -from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
 +from ocs_ci.framework.pytest_customization.marks import (
-+    skipif_external_mode,
-+    skipif_ibm_power,
++        skipif_external_mode,
++        skipif_ibm_power,
 +)
- 
++
+
  log = logging.getLogger(__name__)
- 
-@@ -125,6 +128,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
+
+@@ -126,6 +130,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
  @scale
  @ignore_leftovers
  @skipif_external_mode

--- a/files/ocs-ci/ocs-ci-05-drain.patch
+++ b/files/ocs-ci/ocs-ci-05-drain.patch
@@ -1,5 +1,5 @@
 diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
-index 6f74f782..5b62b869 100644
+index f839c87f..aff5bed5 100644
 --- a/ocs_ci/ocs/node.py
 +++ b/ocs_ci/ocs/node.py
 @@ -204,7 +204,7 @@ def drain_nodes(node_names):
@@ -11,3 +11,4 @@ index 6f74f782..5b62b869 100644
              timeout=1800,
          )
      except TimeoutExpired:
+

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,16 +1,16 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index 672f07f7..8476469b 100644
+index 9b609f15..b13b6240 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -1104,6 +1104,12 @@ def setup_persistent_monitoring():
+@@ -1132,6 +1132,12 @@ def setup_persistent_monitoring():
      """
      Change monitoring backend to OCS
      """
-+
 +    # Validate the storage class exists
 +    retry((CommandFailed), tries=16, delay=15)(
 +        helpers.default_storage_class
 +    )(interface_type=constants.CEPHBLOCKPOOL)
++
 +
      sc = helpers.default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
 


### PR DESCRIPTION
patchfiles=../../files/ocs-ci/ocs-ci-00-ripsaw.patch ../../files/ocs-ci/ocs-ci-01-strimzi.patch ../../files/ocs-ci/ocs-ci-02-skipscaletest.patch ../../files/ocs-ci/ocs-ci-03-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-04-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-05-drain.patch ../../files/ocs-ci/ocs-ci-06-check-sc-exists.patch ../../files/ocs-ci/ocs-ci-07-kafka-drop.patch
ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /home/aditi/pr/rebase/ocs-ci.patch from /home/aditi/pr/rebase/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/ripsaw.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/ripsaw.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml