### PR TITLE
temporary fix for odf deploy failing due to lso version error

### DIFF
--- a/files/ocs-ci/ocs-ci-08-lso-fix.patch
+++ b/files/ocs-ci/ocs-ci-08-lso-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/ocs_ci/utility/localstorage.py b/ocs_ci/utility/localstorage.py
+index eafdc9d3..2f756917 100644
+--- a/ocs_ci/utility/localstorage.py
++++ b/ocs_ci/utility/localstorage.py
+@@ -216,7 +216,7 @@ def get_lso_channel():
+     channel_names = [channel["name"] for channel in channels]
+
+     # Ensure channel_names is sorted
+-    versions = [LooseVersion(name) for name in channel_names]
++    versions = [LooseVersion(name) for name in channel_names if name != "stable"]
+     versions.sort()
+     sorted_versions = [v.vstring for v in versions]
+


### PR DESCRIPTION
temporary patch until this - https://github.com/red-hat-storage/ocs-ci/issues/4948 is resolved.

Generating consolidated patch file /home/aditi/pr/ocs-ci.patch from /home/aditi/pr/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/ripsaw.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/utility/localstorage.py
Patching ocs-ci...
patching file ocs_ci/ocs/ripsaw.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/utility/localstorage.py
