### PR TITLE
Updating kafka-bridge image tag

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -23,7 +23,7 @@ index bdb88deb..0a58e326 100644
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +
 +            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.20.2|quay.io/aaruniaggarwal/kafka-bridge:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.20.3|quay.io/aaruniaggarwal/kafka-bridge:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/jmxtrans:latest|quay.io/aaruniaggarwal/strimzi-jmxtrans:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kaniko-executor:latest|quay.io/aaruniaggarwal/kaniko-executor:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/maven-builder:latest|registry.access.redhat.com/ubi8/openjdk-11:1.3-18|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)


### PR DESCRIPTION
Updating kafka-bridge image tag as tag got updated in upstream strimzi-kafka  repository due to which our patch is not getting applied and testcase is failing. 
new tag used for kafka-bridge is 0.23.0 as mentioned here -> https://github.com/strimzi/strimzi-kafka-operator/blob/main/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml#L85

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>