### PR TITLE
ocs-ci rebase and Adding patch to skip 2 tests

### DIFF
--- a/files/ocs-ci/ocs-ci-02-skipscaletest.patch
+++ b/files/ocs-ci/ocs-ci-02-skipscaletest.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
-index 43cb1aa1..47b5f737 100644
+index 082e4f3b..d61ebb09 100644
 --- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
 +++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
 @@ -20,6 +20,7 @@ from ocs_ci.utility.utils import ceph_health_check
@@ -10,7 +10,7 @@ index 43cb1aa1..47b5f737 100644
  )
 
 
-@@ -41,6 +42,7 @@ logger = logging.getLogger(__name__)
+@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
      ],
  )
  @skipif_aws_i3

--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -116,3 +116,47 @@ index 6816f903..1c4765f7 100644
  class TestCheckTolerationForCephCsiDriverDs(ManageTest):
      """
      Check toleration for Ceph CSI driver DS on non ocs node
+diff --git a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+index 38be410b..0868ef07 100644
+--- a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
++++ b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+@@ -1,7 +1,10 @@
+ import logging
+ import pytest
+
+-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
++from ocs_ci.framework.pytest_customization.marks import (
++        skipif_openshift_dedicated,
++        skipif_ibm_power,
++)
+ from ocs_ci.ocs.node import drain_nodes, schedule_nodes, get_node_zone
+ from ocs_ci.helpers.helpers import get_failure_domin
+ from ocs_ci.framework import config
+@@ -30,6 +33,7 @@ logger = logging.getLogger(__name__)
+ @skipif_external_mode
+ @skipif_openshift_dedicated
+ @pytest.mark.polarion_id("OCS-2594")
++@skipif_ibm_power
+ class TestAddNodeCrashCollector(ManageTest):
+     """
+     Add node with OCS label and verify crashcollector created on new node
+diff --git a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+index 2eb92711..e55cae29 100644
+--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
++++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+@@ -21,6 +21,7 @@ from ocs_ci.framework.pytest_customization.marks import (
+     skipif_bmpsi,
+     bugzilla,
+     skipif_external_mode,
++    skipif_ibm_power,
+ )
+
+ from ocs_ci.helpers.sanity_helpers import Sanity
+@@ -274,6 +275,7 @@ class TestNodeReplacement(ManageTest):
+ @bugzilla("1840539")
+ @pytest.mark.polarion_id("OCS-2535")
+ @skipif_external_mode
++@skipif_ibm_power
+ class TestNodeReplacementTwice(ManageTest):
+     """
+     Node replacement twice:

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index 9b609f15..b13b6240 100644
+index dc1e68ec..0a72484e 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -1132,6 +1132,12 @@ def setup_persistent_monitoring():
+@@ -1146,6 +1146,11 @@ def setup_persistent_monitoring():
      """
      Change monitoring backend to OCS
      """
@@ -10,7 +10,6 @@ index 9b609f15..b13b6240 100644
 +    retry((CommandFailed), tries=16, delay=15)(
 +        helpers.default_storage_class
 +    )(interface_type=constants.CEPHBLOCKPOOL)
-+
 +
      sc = helpers.default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
 


### PR DESCRIPTION
setup-ocs-ci.sh script results:

Generating consolidated patch file /home/aditi/rebase-3/ocs-ci.patch from /home/aditi/rebase-3/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml