### PR TITLE
ocs-ci rebase

### DIFF
--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -71,19 +71,19 @@ index 36b5a124..2ee02469 100644
      """
      Test add capacity when one of the resources gets deleted
 diff --git a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
-index c5fed9a2..871c59ad 100644
+index 76a9c2f5..5eb57b20 100644
 --- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
 +++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
-@@ -5,6 +5,7 @@ from ocs_ci.ocs.cluster import CephCluster
- from ocs_ci.framework.pytest_customization.marks import (
+@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
      skipif_openshift_dedicated,
      skipif_flexy_deployment,
+     skipif_ibm_flash,
 +    skipif_ibm_power,
  )
 
  logger = logging.getLogger(__name__)
-@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
- @skipif_openshift_dedicated
+@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
+ @skipif_ibm_flash
  @ignore_leftovers
  @tier1
 +@skipif_ibm_power
@@ -117,7 +117,7 @@ index 6816f903..1c4765f7 100644
      """
      Check toleration for Ceph CSI driver DS on non ocs node
 diff --git a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
-index 38be410b..0868ef07 100644
+index b1541f0b..50407a0a 100644
 --- a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
 +++ b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
 @@ -1,7 +1,10 @@
@@ -129,10 +129,10 @@ index 38be410b..0868ef07 100644
 +        skipif_openshift_dedicated,
 +        skipif_ibm_power,
 +)
- from ocs_ci.ocs.node import drain_nodes, schedule_nodes, get_node_zone
+ from ocs_ci.ocs.node import drain_nodes, schedule_nodes
  from ocs_ci.helpers.helpers import get_failure_domin
  from ocs_ci.framework import config
-@@ -30,6 +33,7 @@ logger = logging.getLogger(__name__)
+@@ -33,6 +36,7 @@ logger = logging.getLogger(__name__)
  @skipif_external_mode
  @skipif_openshift_dedicated
  @pytest.mark.polarion_id("OCS-2594")

--- a/files/ocs-ci/ocs-ci-05-drain.patch
+++ b/files/ocs-ci/ocs-ci-05-drain.patch
@@ -1,5 +1,5 @@
 diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
-index f839c87f..aff5bed5 100644
+index 906aef59..770d48d5 100644
 --- a/ocs_ci/ocs/node.py
 +++ b/ocs_ci/ocs/node.py
 @@ -204,7 +204,7 @@ def drain_nodes(node_names):
@@ -11,4 +11,3 @@ index f839c87f..aff5bed5 100644
              timeout=1800,
          )
      except TimeoutExpired:
-

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index dc1e68ec..0a72484e 100644
+index 096d5c0d..05862975 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -1146,6 +1146,11 @@ def setup_persistent_monitoring():
+@@ -1152,6 +1152,11 @@ def setup_persistent_monitoring():
      """
      Change monitoring backend to OCS
      """


### PR DESCRIPTION
ocs-ci/ocs-ci-03-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-04-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-05-drain.patch ../../files/ocs-ci/ocs-ci-06-check-sc-exists.patch ../../files/ocs-ci/ocs-ci-07-kafka-drop.patch
ls: cannot access '../../files/ocs-ci/powervs/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /home/aditi/rebase-2/ocs-ci.patch from /home/aditi/rebase-2/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
Collecting pip
