### PR TITLE
ocs-ci rebase

### DIFF
--- a/files/ocs-ci/ocs-ci-05-drain.patch
+++ b/files/ocs-ci/ocs-ci-05-drain.patch
@@ -1,5 +1,5 @@
 diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
-index 906aef59..770d48d5 100644
+index cbc83f2f..38e228a8 100644
 --- a/ocs_ci/ocs/node.py
 +++ b/ocs_ci/ocs/node.py
 @@ -204,7 +204,7 @@ def drain_nodes(node_names):

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index 096d5c0d..05862975 100644
+index 700b3b63..dbea9993 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -1152,6 +1152,11 @@ def setup_persistent_monitoring():
+@@ -1165,6 +1165,11 @@ def setup_persistent_monitoring():
      """
      Change monitoring backend to OCS
      """


### PR DESCRIPTION
platform_patchfiles=
Generating consolidated patch file /home/aditi/rebase-2/ocs-ci.patch from /home/aditi/rebase-2/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
checking file tests/e2e/registry/test_registry_pod_respin.py
checking file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
checking file tests/e2e/registry/test_registry_reboot_node.py
checking file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/registry/test_registry_by_increasing_num_of_image_registry_pods.py
patching file tests/e2e/registry/test_registry_pod_respin.py
patching file tests/e2e/registry/test_registry_pull_and_push_images_to_registry.py
patching file tests/e2e/registry/test_registry_reboot_node.py
patching file tests/e2e/registry/test_registry_shutdown_and_recovery_node.py
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
