### PR TITLE
Adding patch for nodename validation in ocs-ci

### DIFF
--- a/files/ocs-ci/ocs-ci-08-nodename-validation.patch
+++ b/files/ocs-ci/ocs-ci-08-nodename-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/ocs_ci/ocs/resources/storage_cluster.py b/ocs_ci/ocs/resources/storage_cluster.py
+index ed84adc6..a017c9de 100644
+--- a/ocs_ci/ocs/resources/storage_cluster.py
++++ b/ocs_ci/ocs/resources/storage_cluster.py
+@@ -304,7 +304,7 @@ def ocs_install_verification(
+             deviceset_pvcs = [osd.get_node() for osd in get_osd_pods()]
+             # removes duplicate hostname
+             deviceset_pvcs = list(set(deviceset_pvcs))
+-            if config.ENV_DATA.get("platform") == constants.BAREMETAL_PLATFORM or (
++            if config.ENV_DATA.get("platform") == constants.BAREMETAL_PLATFORM or constants.IBM_POWER_PLATFORM or (
+                 config.ENV_DATA.get("flexy_deployment")
+                 and config.ENV_DATA.get("platform") == constants.AWS_PLATFORM
+             ):


### PR DESCRIPTION
Resolving validation error which arose due to change in the naming convention of node names in ocp4-upi-powervs

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>