### PR TITLE
rebased ocs-ci

### DIFF
--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -71,13 +71,13 @@ index 36b5a124..2ee02469 100644
      """
      Test add capacity when one of the resources gets deleted
 diff --git a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
-index e5a429bc..7da4dc66 100644
+index cf472ee8..cd3fa63c 100644
 --- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
 +++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
 @@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
-     skipif_managed_service,
      skipif_flexy_deployment,
      skipif_ibm_flash,
+     skipif_ms_consumer,
 +    skipif_ibm_power,
  )
 

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index fa737f2d..8d21704d 100644
+index e4713354..374090c8 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -1241,6 +1241,11 @@ def setup_persistent_monitoring():
+@@ -1316,6 +1316,11 @@ def setup_persistent_monitoring():
      """
      Change monitoring backend to OCS
      """


### PR DESCRIPTION
Signed-off-by: aditidukle <adukle@redhat.com>

ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /home/aditi/pr/ocs-ci.patch from /home/aditi/pr/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/ocs/resources/storage_cluster.py
checking file ocs_ci/ocs/resources/pod.py
checking file ocs_ci/ocs/scale_noobaa_lib.py
checking file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/ocs/resources/storage_cluster.py
patching file ocs_ci/ocs/resources/pod.py
patching file ocs_ci/ocs/scale_noobaa_lib.py
patching file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
Collecting pip
  Using cached https://files.pythonhosted.org/packages/6a/df/a6ef77a6574781a668791419ffe366c8acd1c3cf4709d210cb53cd5ce1c2/pip-22.0.3-py3-none-any.whl
Collecting setuptools
