### PR TITLE
Updating upgrade script

### DIFF
--- a/scripts/debug-ceph-pods.sh
+++ b/scripts/debug-ceph-pods.sh
@@ -78,7 +78,7 @@ then
     echo | tee -a $log
     mkdir $WORKSPACE/debug-ceph-pods-logs/must-gather
     ocs_operator=`oc get csv | grep ocs-operator | awk {'print $1'}`
-    OCS_VERSION=`oc get csv $ocs_operator -o jsonpath={.spec.version} | cut -c1-3`
+    OCS_VERSION=`oc get csv $ocs_operator -o jsonpath={.spec.version} | cut -d "." -f 1-2`
     oc adm must-gather --image=quay.io/rhceph-dev/ocs-must-gather:latest-$OCS_VERSION --dest-dir=$WORKSPACE/debug-ceph-pods-logs/must-gather | tee -a $log
 fi
 


### PR DESCRIPTION
After Upgrading OCS from one version to another, the supplemental config file needs to be updated for running tier1 test cases. 
Hence updating `ocs_version` under ENV section in the config file.
Also, In order to execute tier tests, we need to add `ocs_csv_channel` in the config file. 

Correcting following command in scripts/debug-ceph-pods.sh as it will not work for ocs_version > 4.9

`OCS_VERSION=oc get csv $ocs_operator -o jsonpath={.spec.version} | cut -c1-3` 


Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>