### PR TITLE
Updating strimzi patch with new image

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -1,17 +1,17 @@
 diff --git a/ocs_ci/ocs/amq.py b/ocs_ci/ocs/amq.py
-index 25a82b33..4b450529 100644
+index 25a82b33..9edaca97 100644
 --- a/ocs_ci/ocs/amq.py
 +++ b/ocs_ci/ocs/amq.py
 @@ -26,7 +26,7 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check, validate_pv
  from ocs_ci.ocs.resources.pvc import get_all_pvc_objs, delete_pvcs
-
+ 
  log = logging.getLogger(__name__)
 -URL = "https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz"
 +URL = "https://get.helm.sh/helm-v2.16.1-linux-ppc64le.tar.gz"
  AMQ_BENCHMARK_NAMESPACE = "tiller"
-
-
-@@ -81,6 +81,16 @@ class AMQ(object):
+ 
+ 
+@@ -81,6 +81,17 @@ class AMQ(object):
              git_clone_cmd = f"git clone {self.repo} "
              run(git_clone_cmd, shell=True, cwd=self.dir, check=True)
              self.amq_dir = "strimzi-kafka-operator/packaging/install/cluster-operator/"
@@ -19,6 +19,7 @@ index 25a82b33..4b450529 100644
 +            log.info(f"Patching 060-Deployment-strimzi-cluster-operator.yaml for ppc64le images in {self.amq_dir}")
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.1.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.1.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +
 +            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.21.4|quay.io/aaruniaggarwal/kafka-bridge:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
@@ -28,7 +29,7 @@ index 25a82b33..4b450529 100644
              self.amq_kafka_pers_yaml = (
                  "strimzi-kafka-operator/packaging/examples/kafka/kafka-persistent.yaml"
              )
-@@ -617,9 +627,9 @@ class AMQ(object):
+@@ -617,9 +628,9 @@ class AMQ(object):
          # Install helm cli (version v2.16.0 as we need tiller component)
          # And create tiller pods
          wget_cmd = f"wget -c --read-timeout=5 --tries=0 {URL}"
@@ -40,7 +41,7 @@ index 25a82b33..4b450529 100644
              f" --service-account {tiller_namespace}"
          )
          exec_cmd(cmd=wget_cmd, cwd=self.dir)
-@@ -641,7 +651,7 @@ class AMQ(object):
+@@ -641,7 +652,7 @@ class AMQ(object):
          values = templating.load_yaml(constants.AMQ_BENCHMARK_VALUE_YAML)
          values["numWorkers"] = num_of_clients
          benchmark_cmd = (
@@ -49,7 +50,7 @@ index 25a82b33..4b450529 100644
              f" --name {benchmark_pod_name} --tiller-namespace {tiller_namespace}"
          )
          exec_cmd(cmd=benchmark_cmd, cwd=self.dir)
-@@ -987,7 +997,7 @@ class AMQ(object):
+@@ -987,7 +998,7 @@ class AMQ(object):
          if self.benchmark:
              # Delete the helm app
              try:


### PR DESCRIPTION
Upstream strimzi-kafka git repository added new image `quay.io/strimzi/kafka:latest-kafka-3.0.1` due to which our tier1 test case was failing. Hence updating our strimzi patchfile. 

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>