### PR TITLE
Updating strimzi kafka images

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -20,9 +20,10 @@ index 7edfcb1e..10b25345 100644
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.1.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.1.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.2.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.2.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +
 +            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.21.4|quay.io/aaruniaggarwal/kafka-bridge:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.21.5|quay.io/aaruniaggarwal/kafka-bridge:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/jmxtrans:latest|quay.io/aaruniaggarwal/strimzi-jmxtrans:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kaniko-executor:latest|quay.io/aaruniaggarwal/kaniko-executor:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/maven-builder:latest|quay.io/aaruniaggarwal/maven-builder:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)


### PR DESCRIPTION
A new image got added in the Upstream strimzi-kafka github repository(https://github.com/strimzi/strimzi-kafka-operator/blob/main/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml). Hence updating the patch.  

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>