### PR TITLE
Updating strimzi image

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -1,5 +1,5 @@
 diff --git a/ocs_ci/ocs/amq.py b/ocs_ci/ocs/amq.py
-index 9ed0becc..c4ae1174 100644
+index 9ed0becc..0f5fb6e8 100644
 --- a/ocs_ci/ocs/amq.py
 +++ b/ocs_ci/ocs/amq.py
 @@ -26,7 +26,7 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check, validate_pv
@@ -11,15 +11,14 @@ index 9ed0becc..c4ae1174 100644
  AMQ_BENCHMARK_NAMESPACE = "tiller"
  
  
-@@ -81,6 +81,18 @@ class AMQ(object):
+@@ -81,6 +81,17 @@ class AMQ(object):
              git_clone_cmd = f"git clone {self.repo} "
              run(git_clone_cmd, shell=True, cwd=self.dir, check=True)
              self.amq_dir = "strimzi-kafka-operator/packaging/install/cluster-operator/"
 +            self.sed_dir = os.path.join(self.dir, self.amq_dir)
 +            log.info(f"Patching 060-Deployment-strimzi-cluster-operator.yaml for ppc64le images in {self.amq_dir}")
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.1.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.1.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.0.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.0.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
++            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.1.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.1.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.2.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.2.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
 +
 +            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
@@ -30,7 +29,7 @@ index 9ed0becc..c4ae1174 100644
              self.amq_kafka_pers_yaml = (
                  "strimzi-kafka-operator/packaging/examples/kafka/kafka-persistent.yaml"
              )
-@@ -621,9 +633,9 @@ class AMQ(object):
+@@ -621,9 +632,9 @@ class AMQ(object):
          # Install helm cli (version v2.16.0 as we need tiller component)
          # And create tiller pods
          wget_cmd = f"wget -c --read-timeout=5 --tries=0 {URL}"
@@ -42,7 +41,7 @@ index 9ed0becc..c4ae1174 100644
              f" --service-account {tiller_namespace}"
          )
          exec_cmd(cmd=wget_cmd, cwd=self.dir)
-@@ -645,7 +657,7 @@ class AMQ(object):
+@@ -645,7 +656,7 @@ class AMQ(object):
          values = templating.load_yaml(constants.AMQ_BENCHMARK_VALUE_YAML)
          values["numWorkers"] = num_of_clients
          benchmark_cmd = (
@@ -51,7 +50,7 @@ index 9ed0becc..c4ae1174 100644
              f" --name {benchmark_pod_name} --tiller-namespace {tiller_namespace}"
          )
          exec_cmd(cmd=benchmark_cmd, cwd=self.dir)
-@@ -991,7 +1003,7 @@ class AMQ(object):
+@@ -991,7 +1002,7 @@ class AMQ(object):
          if self.benchmark:
              # Delete the helm app
              try:


### PR DESCRIPTION
New image `quay.io/strimzi/kafka:latest-kafka-3.1.1` is added in the upstream strimzi-kafka repository and the following two images are removed from the upstream repository: `quay.io/strimzi/kafka:latest-kafka-3.0.0` and `quay.io/strimzi/kafka:latest-kafka-3.0.1` . Hence updating the patch. 

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>