### PR TITLE
Fixing scipy==1.8.1 installation error

### DIFF
--- a/scripts/setup-ocs-ci.sh
+++ b/scripts/setup-ocs-ci.sh
@@ -84,7 +84,7 @@ python3.8 -m venv $WORKSPACE/venv
 
 source $WORKSPACE/venv/bin/activate		# activate named python venv
 
-pip3 install --upgrade pip setuptools wheel Cython==3.0.0a10
+pip3 install --upgrade pip setuptools==63.2.0 wheel Cython==3.0.0a10
 pip3 install gevent==20.9.0 --no-build-isolation
 pip3 install -r requirements.txt 
 pip3 install yq


### PR DESCRIPTION
Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>

The setup script fails to install scipy version 1.8.1 due to setuptools version==65.
Related issue: https://github.com/numpy/numpy/issues/22135 

Hence degrading the setuptools version to `63.2.0`