### PR TITLE
Removing own build images from strimzi patch for 4.13

### DIFF
--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -1,5 +1,5 @@
 diff --git a/ocs_ci/ocs/amq.py b/ocs_ci/ocs/amq.py
-index 9ed0becc..a6fb4118 100644
+index 9ed0becc..a30e618a 100644
 --- a/ocs_ci/ocs/amq.py
 +++ b/ocs_ci/ocs/amq.py
 @@ -26,7 +26,7 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check, validate_pv
@@ -11,25 +11,7 @@ index 9ed0becc..a6fb4118 100644
  AMQ_BENCHMARK_NAMESPACE = "tiller"
  
  
-@@ -81,6 +81,17 @@ class AMQ(object):
-             git_clone_cmd = f"git clone {self.repo} "
-             run(git_clone_cmd, shell=True, cwd=self.dir, check=True)
-             self.amq_dir = "strimzi-kafka-operator/packaging/install/cluster-operator/"
-+            self.sed_dir = os.path.join(self.dir, self.amq_dir)
-+            log.info(f"Patching 060-Deployment-strimzi-cluster-operator.yaml for ppc64le images in {self.amq_dir}")
-+            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.4.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.4.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.4.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.4.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.5.0|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.5.0|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka:latest-kafka-3.5.1|quay.io/aaruniaggarwal/strimzi-kafka:latest-kafka-3.5.1|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+
-+            run("sed -i 's|quay.io/strimzi/operator:latest|quay.io/aaruniaggarwal/strimzi-operator:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kafka-bridge:0.26.0|quay.io/aaruniaggarwal/kafka-bridge:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/kaniko-executor:latest|quay.io/aaruniaggarwal/kaniko-executor:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-+            run("sed -i 's|quay.io/strimzi/maven-builder:latest|quay.io/aaruniaggarwal/maven-builder:latest|g' 060-Deployment-strimzi-cluster-operator.yaml" , shell=True, check=True, cwd=self.sed_dir)
-             self.amq_kafka_pers_yaml = (
-                 "strimzi-kafka-operator/packaging/examples/kafka/kafka-persistent.yaml"
-             )
-@@ -621,9 +632,9 @@ class AMQ(object):
+@@ -621,9 +621,9 @@ class AMQ(object):
          # Install helm cli (version v2.16.0 as we need tiller component)
          # And create tiller pods
          wget_cmd = f"wget -c --read-timeout=5 --tries=0 {URL}"
@@ -41,7 +23,7 @@ index 9ed0becc..a6fb4118 100644
              f" --service-account {tiller_namespace}"
          )
          exec_cmd(cmd=wget_cmd, cwd=self.dir)
-@@ -645,7 +656,7 @@ class AMQ(object):
+@@ -645,7 +645,7 @@ class AMQ(object):
          values = templating.load_yaml(constants.AMQ_BENCHMARK_VALUE_YAML)
          values["numWorkers"] = num_of_clients
          benchmark_cmd = (
@@ -50,7 +32,7 @@ index 9ed0becc..a6fb4118 100644
              f" --name {benchmark_pod_name} --tiller-namespace {tiller_namespace}"
          )
          exec_cmd(cmd=benchmark_cmd, cwd=self.dir)
-@@ -991,7 +1002,7 @@ class AMQ(object):
+@@ -991,7 +991,7 @@ class AMQ(object):
          if self.benchmark:
              # Delete the helm app
              try:


### PR DESCRIPTION
Removing own built images as multi-arch images are now available in https://quay.io/organization/strimzi

Signed-off-by: Aaruni Aggarwal [aaruniagg@gmail.com](mailto:aaruniagg@gmail.com)