### PR TITLE
Updating nginx:fio image for ppc64le

### DIFF
--- a/files/ocs-ci/ocs-ci-15-log-rotate.patch
+++ b/files/ocs-ci/ocs-ci-15-log-rotate.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/manage/z_cluster/test_rook_ceph_log_rotate.py b/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
-index 28e36afb..64537bf5 100644
+index 73d22858..27750132 100644
 --- a/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
 +++ b/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
-@@ -90,7 +90,7 @@ class TestRookCephLogRotate(ManageTest):
+@@ -92,7 +92,7 @@ class TestRookCephLogRotate(ManageTest):
              else f"{self.podtype_id[pod_type][2]}{self.podtype_id[pod_type][1]}"
          )
          cnt_logs = len(re.findall(expected_string, output_cmd))

--- a/files/ocs-ci/ocs-ci-16-nginx-fio-image.patch
+++ b/files/ocs-ci/ocs-ci-16-nginx-fio-image.patch
@@ -1,0 +1,52 @@
+diff --git a/ocs_ci/templates/CSI/cephfs/pod.yaml b/ocs_ci/templates/CSI/cephfs/pod.yaml
+index aa878377..81e8c81b 100644
+--- a/ocs_ci/templates/CSI/cephfs/pod.yaml
++++ b/ocs_ci/templates/CSI/cephfs/pod.yaml
+@@ -6,7 +6,7 @@ metadata:
+ spec:
+   containers:
+    - name: web-server
+-     image: quay.io/ocsci/nginx:fio
++     image: quay.io/aaruniaggarwal/nginx:fio
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www/html
+diff --git a/ocs_ci/templates/CSI/rbd/pod.yaml b/ocs_ci/templates/CSI/rbd/pod.yaml
+index 34eb5984..aa4d458c 100644
+--- a/ocs_ci/templates/CSI/rbd/pod.yaml
++++ b/ocs_ci/templates/CSI/rbd/pod.yaml
+@@ -7,7 +7,7 @@ metadata:
+ spec:
+   containers:
+    - name: web-server
+-     image: quay.io/ocsci/nginx:fio
++     image: quay.io/aaruniaggarwal/nginx:fio
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www/html
+diff --git a/ocs_ci/templates/app-pods/nginx.yaml b/ocs_ci/templates/app-pods/nginx.yaml
+index 62f641f7..58ab2ea2 100644
+--- a/ocs_ci/templates/app-pods/nginx.yaml
++++ b/ocs_ci/templates/app-pods/nginx.yaml
+@@ -7,7 +7,7 @@ metadata:
+ spec:
+   containers:
+    - name: web-server
+-     image: quay.io/ocsci/nginx:fio
++     image: quay.io/aaruniaggarwal/nginx:fio
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www/html
+diff --git a/ocs_ci/templates/app-pods/raw_block_pod.yaml b/ocs_ci/templates/app-pods/raw_block_pod.yaml
+index 2569e251..e5738cc1 100644
+--- a/ocs_ci/templates/app-pods/raw_block_pod.yaml
++++ b/ocs_ci/templates/app-pods/raw_block_pod.yaml
+@@ -5,7 +5,7 @@ metadata:
+ spec:
+   containers:
+     - name: my-container
+-      image: quay.io/ocsci/nginx:fio
++      image: quay.io/aaruniaggarwal/nginx:fio
+       securityContext:
+          capabilities: {}
+       volumeDevices:


### PR DESCRIPTION
creating a new patch which updates nginx:fio image for ppc64le in ocs-ci repository, As the image used ocs-ci repo is not for ppc64le.   

Signed-off-by: Aaruni Aggarwal [aaruniagg@gmail.com](mailto:aaruniagg@gmail.com)