### PR TITLE
Rebasing ocs-ci 4.17 Changed the required patch files

### DIFF
--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
-index bab85f60..9f2a7ccf 100644
+index fb0c8470..af225537 100644
 --- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
 +++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
 @@ -2,6 +2,10 @@ import logging
@@ -13,7 +13,7 @@ index bab85f60..9f2a7ccf 100644
  from ocs_ci.ocs.cluster import is_flexible_scaling_enabled
  from ocs_ci.ocs.ocp import OCP
  from ocs_ci.ocs.resources import pod as pod_helpers
-@@ -42,6 +46,7 @@ logger = logging.getLogger(__name__)
+@@ -44,6 +48,7 @@ logger = logging.getLogger(__name__)
  @ignore_leftovers
  @tier2
  @skipif_bm

--- a/files/ocs-ci/ocs-ci-05-drain.patch
+++ b/files/ocs-ci/ocs-ci-05-drain.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
-index 8c549bef..dc8b159b 100644
+index c594472d..6715a715 100644
 --- a/ocs_ci/ocs/node.py
 +++ b/ocs_ci/ocs/node.py
-@@ -263,7 +263,7 @@ def drain_nodes(node_names, timeout=1800, disable_eviction=False):
+@@ -264,7 +264,7 @@ def drain_nodes(node_names, timeout=1800, disable_eviction=False):
          else:
              ocp.exec_oc_cmd(
                  f"adm drain {node_names_str} --force=true --ignore-daemonsets "
@@ -11,3 +11,4 @@ index 8c549bef..dc8b159b 100644
                  timeout=timeout,
              )
      except TimeoutExpired:
+

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index d693c7df..0c5d2d38 100644
+index cefe194d..3feafb40 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -2270,6 +2270,11 @@ def setup_persistent_monitoring():
+@@ -2517,6 +2517,11 @@ def setup_persistent_monitoring():
      """
      Change monitoring backend to OCS
      """
@@ -14,3 +14,4 @@ index d693c7df..0c5d2d38 100644
      sc = helpers.default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
 
      # Get the list of monitoring pods
+

--- a/files/ocs-ci/ocs-ci-08-nodename-validation.patch
+++ b/files/ocs-ci/ocs-ci-08-nodename-validation.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/resources/storage_cluster.py b/ocs_ci/ocs/resources/storage_cluster.py
-index 94c7b5ba..597d0861 100644
+index 9d340856..b13ae820 100644
 --- a/ocs_ci/ocs/resources/storage_cluster.py
 +++ b/ocs_ci/ocs/resources/storage_cluster.py
-@@ -555,7 +555,7 @@ def ocs_install_verification(
+@@ -556,7 +556,7 @@ def ocs_install_verification(
              # removes duplicate hostname
              deviceset_pvcs = list(set(deviceset_pvcs))
              if (
@@ -11,3 +11,4 @@ index 94c7b5ba..597d0861 100644
                  or config.ENV_DATA.get("platform") == constants.AWS_PLATFORM
              ):
                  deviceset_pvcs = [
+

--- a/files/ocs-ci/ocs-ci-09-podname-change.patch
+++ b/files/ocs-ci/ocs-ci-09-podname-change.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/resources/pod.py b/ocs_ci/ocs/resources/pod.py
-index b8a7f548..a4c4c7c5 100644
+index 49ef7ac8..bdd0b6c2 100644
 --- a/ocs_ci/ocs/resources/pod.py
 +++ b/ocs_ci/ocs/resources/pod.py
-@@ -2081,8 +2081,13 @@ def wait_for_storage_pods(timeout=200):
+@@ -2091,8 +2091,13 @@ def wait_for_storage_pods(timeout=200):
 
      for pod_obj in all_pod_obj:
          state = constants.STATUS_RUNNING
@@ -16,5 +16,6 @@ index b8a7f548..a4c4c7c5 100644
 +            if any(i in pod_obj.name for i in ["-1-deploy", "ocs-deviceset"]):
 +                state = constants.STATUS_COMPLETED
          helpers.wait_for_resource_state(resource=pod_obj, state=state, timeout=timeout)
+
 
 

--- a/files/ocs-ci/ocs-ci-12-skip-known-failures.patch
+++ b/files/ocs-ci/ocs-ci-12-skip-known-failures.patch
@@ -221,7 +221,7 @@ index c081a253..9769edfe 100644
          ],
      )
 diff --git a/tests/functional/z_cluster/nodes/test_nodes_restart.py b/tests/functional/z_cluster/nodes/test_nodes_restart.py
-index 70172f4a..a670fe60 100644
+index 5eb6f0b2..9bd95d6e 100644
 --- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
 +++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
 @@ -1,7 +1,7 @@
@@ -233,7 +233,7 @@ index 70172f4a..a670fe60 100644
  from ocs_ci.framework.testlib import (
      tier4a,
      tier4b,
-@@ -139,6 +139,7 @@ class TestNodesRestart(ManageTest):
+@@ -140,6 +140,7 @@ class TestNodesRestart(ManageTest):
      )
      @skipif_ibm_cloud
      @skipif_vsphere_ipi
@@ -241,3 +241,4 @@ index 70172f4a..a670fe60 100644
      def test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node(
          self,
          nodes,
+

--- a/files/ocs-ci/ocs-ci-13-increase-timeout.patch
+++ b/files/ocs-ci/ocs-ci-13-increase-timeout.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/helpers/helpers.py b/ocs_ci/helpers/helpers.py
-index 719dc256..2a87a82b 100644
+index 21546c98..931c5393 100644
 --- a/ocs_ci/helpers/helpers.py
 +++ b/ocs_ci/helpers/helpers.py
-@@ -100,7 +100,7 @@ def create_resource(do_reload=True, **kwargs):
+@@ -99,7 +99,7 @@ def create_resource(do_reload=True, **kwargs):
      return ocs_obj
 
 

--- a/files/ocs-ci/ocs-ci-14-apply-icsp.patch
+++ b/files/ocs-ci/ocs-ci-14-apply-icsp.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/utility/deployment.py b/ocs_ci/utility/deployment.py
-index 0375637f..847ea17a 100644
+index cf09484f..effc7164 100644
 --- a/ocs_ci/utility/deployment.py
 +++ b/ocs_ci/utility/deployment.py
-@@ -133,7 +133,7 @@ def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
+@@ -138,7 +138,7 @@ def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
      pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
      create_directory_path(icsp_file_dest_dir)
      cmd = (
@@ -11,3 +11,4 @@ index 0375637f..847ea17a 100644
          f"{image} --confirm "
          f"--path {icsp_file_location}:{icsp_file_dest_dir}"
      )
+

--- a/files/ocs-ci/ocs-ci-17-scipy-fix.patch
+++ b/files/ocs-ci/ocs-ci-17-scipy-fix.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index 3b2e404f..3e8c1bb3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -48,11 +48,11 @@ setup(
+         "google-cloud-storage==2.6.0",
+         "google-auth==2.14.1",
+         "elasticsearch==8.11.1",
+-        "numpy==1.22.0",
++        "numpy==1.26.4",
+         "pandas==1.5.2",
+         "tabulate==0.9.0",
+         "python-ipmi==0.4.2",
+-        "scipy==1.10.0",
++        "scipy==1.11.0",
+         "PrettyTable==0.7.2",
+         "azure-common==1.1.25",
+         "azure-mgmt-compute==12.0.0",

--- a/samples/cron/test-cron-ocs.sh
+++ b/samples/cron/test-cron-ocs.sh
@@ -17,8 +17,8 @@ export PLATFORM=${PLATFORM:="kvm"}                              # Also supported
 # These environment variables are optional, but should be set for cron jobs,
 # so that CLUSTER_ID_PREFIX below is properly initialized for powervs.
 
-export OCP_VERSION=${OCP_VERSION:=4.16}                          # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}
+export OCP_VERSION=${OCP_VERSION:=4.17}                          # 4.12-4.17 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 
 
 # These are optional for KVM OCP cluster create.  Default values are shown

--- a/samples/dev-ocs-fio.sh
+++ b/samples/dev-ocs-fio.sh
@@ -16,8 +16,8 @@ export PLATFORM=${PLATFORM:=powervs}                            # Only powervs a
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.16}                          # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}
+export OCP_VERSION=${OCP_VERSION:=4.17}                          # 4.12-4.17 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 
 # These are optional and apply only to kvm and powervs for now. They are presently ignored on powervm
 

--- a/samples/dev-ocs-perf.sh
+++ b/samples/dev-ocs-perf.sh
@@ -32,8 +32,8 @@ export PLATFORM=${PLATFORM:=powervs}                            # Only powervs a
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.16}                          # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}
+export OCP_VERSION=${OCP_VERSION:=4.17}                          # 4.12-4.17 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 
 # These are optional and apply only to kvm and powervs for now.  They are presently ignored on powervm
 

--- a/samples/dev-ocs.sh
+++ b/samples/dev-ocs.sh
@@ -16,8 +16,8 @@ export PLATFORM=${PLATFORM:="kvm"}                              # Also supported
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.16}                          # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}
+export OCP_VERSION=${OCP_VERSION:=4.17}                          # 4.12-4.17 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 
 # These are optional for KVM OCP cluster create.  Default values are shown
 

--- a/samples/powervs-test-ocs.sh
+++ b/samples/powervs-test-ocs.sh
@@ -5,8 +5,8 @@
 export PLATFORM=powervs # Supports powervs only
 #export RHID_USERNAME=<your rh subscription id>
 #export RHID_PASSWORD=<your rh subscription password>
-export OCP_VERSION=${OCP_VERSION:=4.16} # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}
+export OCP_VERSION=${OCP_VERSION:=4.17} # 4.12-4.17 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 #export PVS_API_KEY=<your key>
 #export FIPS_ENABLEMENT=false
 # These are optional for PowerVS OCP cluster create.  Default values are shown

--- a/samples/test-ocs-perf.sh
+++ b/samples/test-ocs-perf.sh
@@ -32,8 +32,8 @@ export PLATFORM=${PLATFORM:=powervs}                            # Only powervs a
 
 # These environment variables are optional for all platforms
 #export FIPS_ENABLEMENT=false
-export OCP_VERSION=${OCP_VERSION:=4.16}                          # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}
+export OCP_VERSION=${OCP_VERSION:=4.17}                          # 4.12-4.17 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 
 # These are optional and apply only to kvm and powervs.  They are presently ignored on powervm
 

--- a/samples/test-ocs.sh
+++ b/samples/test-ocs.sh
@@ -16,8 +16,8 @@ export PLATFORM=${PLATFORM:="kvm"}                              # Also supported
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.16}                          # 4.5-4.16 are supported
-export OCS_VERSION=${OCS_VERSION:=4.16}                          # 4.7 also
+export OCP_VERSION=${OCP_VERSION:=4.17}                          # 4.12-4.16 are supported
+export OCS_VERSION=${OCS_VERSION:=4.17}
 
 
 # These are optional for KVM OCP cluster create.  Default values are shown

--- a/scripts/helper/create-cluster.sh
+++ b/scripts/helper/create-cluster.sh
@@ -11,72 +11,9 @@ ARG1=$1
 # RHCOS boot images are released less frequently, but follow the same version numbering scheme
 
 case "$OCP_VERSION" in
-	4.4)
-		OCP_RELEASE="4.4.33"				# Latest release of OCP 4.4 at this time
-		RHCOS_VERSION="4.4"
-		if [ -z "$RHCOS_RELEASE" ]; then
-			RHCOS_RELEASE="4.4.9"			# Latest release of RHCOS 4.4 at this time
-		fi
-		RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.5)
-		OCP_RELEASE="4.5.41"				# Latest release of OCP 4.5 at this time
-		RHCOS_VERSION="4.5"
-		if [ -z "$RHCOS_RELEASE" ]; then
-			RHCOS_RELEASE="4.5.4"			# Latest release of RHCOS 4.5 at this time
-		fi
-		RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.6)
-		OCP_RELEASE="4.6.62"				# Latest release of OCP 4.6 at this time
-		RHCOS_VERSION="4.6"
-		if [ -z "$RHCOS_RELEASE" ]; then
-			RHCOS_RELEASE="4.6.47"			# Latest release of RHCOS 4.6 at this time
-		fi
-		RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.7)
-		OCP_RELEASE="4.7.60"
-		RHCOS_VERSION="4.7"
-		if [ -z "$RHCOS_RELEASE" ]; then
-			RHCOS_RELEASE="4.7.33"                   # Latest release of RHCOS 4.7 at this time
-		fi
-		RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.8)
-		OCP_RELEASE="4.8.57"
-		RHCOS_VERSION="4.8"
-		if [ -z "$RHCOS_RELEASE" ]; then
-			RHCOS_RELEASE="4.8.14"                   # Latest release of RHCOS 4.8 at this time
-		fi
-		RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.9)
-		OCP_RELEASE="4.9.59"
-		RHCOS_VERSION="4.9"
-		if [ -z "$RHCOS_RELEASE" ]; then
-			RHCOS_RELEASE="4.9.45"                   # Latest release of RHCOS 4.9 at this time
-		fi
-		RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.10)
-		OCP_RELEASE="4.10.67"
-		RHCOS_VERSION="4.10"
-                if [ -z "$RHCOS_RELEASE" ]; then
-                        RHCOS_RELEASE="4.10.37"                   # Latest release of RHCOS 4.10 at this time
-                fi
-                RHCOS_SUFFIX="-$RHCOS_RELEASE"
-		;;
-	4.11)
-                OCP_RELEASE="4.11.59"
-                RHCOS_VERSION="4.11"
-                if [ -z "$RHCOS_RELEASE" ]; then
-                        RHCOS_RELEASE="4.11.48"                   # Latest release of RHCOS 4.11 at this time
-                fi
-                RHCOS_SUFFIX="-$RHCOS_RELEASE"
-                ;;
+
 	4.12)
-		OCP_RELEASE="4.12.55"
+		OCP_RELEASE="4.12.60"
                 RHCOS_VERSION="4.12"
                 if [ -z "$RHCOS_RELEASE" ]; then
                         RHCOS_RELEASE="4.12.30"                   # Latest release of RHCOS 4.12 at this time
@@ -84,7 +21,7 @@ case "$OCP_VERSION" in
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
 		;;
         4.13)
-                OCP_RELEASE="4.13.40"
+                OCP_RELEASE="4.13.45"
                 RHCOS_VERSION="4.13"
                 if [ -z "$RHCOS_RELEASE" ]; then
                         RHCOS_RELEASE="4.13.10"                   # Latest release of RHCOS 4.13 at this time
@@ -92,7 +29,7 @@ case "$OCP_VERSION" in
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;
 	4.14)
-                OCP_RELEASE="4.14.21"
+                OCP_RELEASE="4.14.33"
                 RHCOS_VERSION="4.14"
                 if [ -z "$RHCOS_RELEASE" ]; then
                         RHCOS_RELEASE="4.14.15"                   # Latest release of RHCOS 4.14 at this time
@@ -100,21 +37,30 @@ case "$OCP_VERSION" in
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;
         4.15)
-                OCP_RELEASE="4.15.9"
+                OCP_RELEASE="4.15.22"
                 RHCOS_VERSION="4.15"
                 if [ -z "$RHCOS_RELEASE" ]; then
                         RHCOS_RELEASE="4.15.0"                   # Latest release of RHCOS 4.14 at this time
                 fi
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;	
-	4.16)
+        4.16)
+                OCP_RELEASE="4.16.3"
+                RHCOS_VERSION="4.16"
+                if [ -z "$RHCOS_RELEASE" ]; then
+                        RHCOS_RELEASE="4.16.0"                   # Latest release of RHCOS 4.14 at this time
+                fi
+                RHCOS_SUFFIX="-$RHCOS_RELEASE"
+                ;;
+
+	4.17)
                 unset OCP_RELEASE
-                RHCOS_VERSION="4.15"
+                RHCOS_VERSION="4.16"
                 unset RHCOS_RELEASE
                 RHCOS_SUFFIX="-$RHCOS_VERSION"
                 ;;	
 	*)
-		echo "Invalid OCP_VERSION=$OCP_VERSION.  Supported versions are 4.4 - 4.16"
+		echo "Invalid OCP_VERSION=$OCP_VERSION.  Supported versions are 4.12 - 4.17"
 		exit 1
 esac
 

--- a/scripts/helper/parameters.sh
+++ b/scripts/helper/parameters.sh
@@ -12,9 +12,9 @@ export RHID_KEY=${RHID_KEY:=""}
 
 export PLATFORM=${PLATFORM:="kvm"}
 
-export OCP_VERSION=${OCP_VERSION:="4.16"}
+export OCP_VERSION=${OCP_VERSION:="4.17"}
 
-export OCS_VERSION=${OCS_VERSION:="4.16"}
+export OCS_VERSION=${OCS_VERSION:="4.17"}
 export OCS_REGISTRY_IMAGE=${OCS_REGISTRY_IMAGE:="quay.io/rhceph-dev/ocs-registry:latest-stable-$OCS_VERSION"}
 export OPTIONAL_OPERATORS_IMAGE=${OPTIONAL_OPERATORS_IMAGE:="quay.io/openshift-release-dev/ocp-release-nightly:iib-int-index-art-operators-$OCP_VERSION"}
 

--- a/scripts/run-fio.sh
+++ b/scripts/run-fio.sh
@@ -237,13 +237,10 @@ oc project default >/dev/null 2>&1
 ocs_operator=`oc get csv -n openshift-storage | grep ocs-operator | awk {'print $1'}`
 ocs_version=`oc get csv $ocs_operator -n openshift-storage -o jsonpath={.spec.version} | cut -d "." -f 1-2`
 cephblockpool=$(oc -n openshift-storage rsh $ceph_tools ceph df | grep ocs-storagecluster-cephblockpool)
-if [[ $ocs_version == "4.9" || $ocs_version == "4.10" || $ocs_version == "4.11" || $ocs_version == "4.12" || $ocs_version == "4.13" || $ocs_version == "4.14" || $ocs_version == "4.15" || $ocs_version == "4.16" ]]; then
-        max_avail_GiB=$(echo $cephblockpool | awk '{print $10}')
-        max_avail_unit=$(echo $cephblockpool | awk '{print $11}')
-else
-        max_avail_GiB=$(echo $cephblockpool | awk '{print $9}')
-        max_avail_unit=$(echo $cephblockpool | awk '{print $10}')
-fi
+
+max_avail_GiB=$(echo $cephblockpool | awk '{print $10}')
+max_avail_unit=$(echo $cephblockpool | awk '{print $11}')
+
 
 if [ "$max_avail_unit" == TiB ]; then
         max_avail_GiB=$(echo $max_avail_GiB*1000 | bc)


### PR DESCRIPTION
**Output setup script before applying patch**
```
Generating consolidated patch file /root/shilpi-rebase/ocs-ci.patch from /root/shilpi-rebase/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
Hunk #2 succeeded at 48 (offset 2 lines).
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
Hunk #1 succeeded at 264 (offset 1 line).
checking file ocs_ci/deployment/deployment.py
Hunk #1 succeeded at 2517 (offset 247 lines).
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/ocs/resources/storage_cluster.py
Hunk #1 succeeded at 556 (offset 1 line).
checking file ocs_ci/ocs/resources/pod.py
Hunk #1 succeeded at 2091 (offset 10 lines).
checking file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
checking file ocs_ci/deployment/helpers/lso_helpers.py
checking file tests/functional/z_cluster/test_ceph_default_values_check.py
checking file tests/functional/z_cluster/test_must_gather.py
checking file tests/functional/object/mcg/test_s3_with_java_sdk.py
checking file tests/functional/object/mcg/test_noobaa_secret.py
checking file tests/functional/z_cluster/test_hugepages.py
checking file tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
checking file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
checking file tests/functional/object/mcg/test_mcg_resources_disruptions.py
checking file tests/functional/object/mcg/test_host_node_failure.py
checking file tests/functional/z_cluster/nodes/test_nodes_restart.py
Hunk #2 succeeded at 140 (offset 1 line).
checking file ocs_ci/helpers/helpers.py
Hunk #1 succeeded at 99 (offset -1 lines).
checking file ocs_ci/utility/deployment.py
Hunk #1 succeeded at 138 (offset 5 lines).
checking file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
checking file ocs_ci/templates/CSI/cephfs/pod.yaml
checking file ocs_ci/templates/CSI/rbd/pod.yaml
checking file ocs_ci/templates/app-pods/nginx.yaml
checking file ocs_ci/templates/app-pods/raw_block_pod.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
Hunk #2 succeeded at 48 (offset 2 lines).
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
Hunk #1 succeeded at 264 (offset 1 line).
patching file ocs_ci/deployment/deployment.py
Hunk #1 succeeded at 2517 (offset 247 lines).
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/ocs/resources/storage_cluster.py
Hunk #1 succeeded at 556 (offset 1 line).
patching file ocs_ci/ocs/resources/pod.py
Hunk #1 succeeded at 2091 (offset 10 lines).
patching file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
patching file ocs_ci/deployment/helpers/lso_helpers.py
patching file tests/functional/z_cluster/test_ceph_default_values_check.py
patching file tests/functional/z_cluster/test_must_gather.py
patching file tests/functional/object/mcg/test_s3_with_java_sdk.py
patching file tests/functional/object/mcg/test_noobaa_secret.py
patching file tests/functional/z_cluster/test_hugepages.py
patching file tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
patching file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
patching file tests/functional/object/mcg/test_mcg_resources_disruptions.py
patching file tests/functional/object/mcg/test_host_node_failure.py
patching file tests/functional/z_cluster/nodes/test_nodes_restart.py
Hunk #2 succeeded at 140 (offset 1 line).
patching file ocs_ci/helpers/helpers.py
Hunk #1 succeeded at 99 (offset -1 lines).
patching file ocs_ci/utility/deployment.py
Hunk #1 succeeded at 138 (offset 5 lines).
patching file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
patching file ocs_ci/templates/CSI/cephfs/pod.yaml
patching file ocs_ci/templates/CSI/rbd/pod.yaml
patching file ocs_ci/templates/app-pods/nginx.yaml
patching file ocs_ci/templates/app-pods/raw_block_pod.yaml
Requirement already satisfied: pip in /root/shilpi-rebase/venv/lib/python3.9/site-packages (21.2.3)
Collecting pip
  Using cached pip-24.1.2-py3-none-any.whl (1.8 MB)
Collecting setuptools==63.2.0
```
**Output setup script after applying the changed patch files**
```
~/shilpi-rebase/ocs-upi-kvm/src/ocs-ci ~/shilpi-rebase/ocs-upi-kvm/scripts
patchfiles=../../files/ocs-ci/ocs-ci-00-ripsaw.patch ../../files/ocs-ci/ocs-ci-01-strimzi.patch ../../files/ocs-ci/ocs-ci-02-skipscaletest.patch ../../files/ocs-ci/ocs-ci-03-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-04-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-05-drain.patch ../../files/ocs-ci/ocs-ci-06-check-sc-exists.patch ../../files/ocs-ci/ocs-ci-07-kafka-drop.patch ../../files/ocs-ci/ocs-ci-08-nodename-validation.patch ../../files/ocs-ci/ocs-ci-09-podname-change.patch ../../files/ocs-ci/ocs-ci-10-logwriter.patch ../../files/ocs-ci/ocs-ci-11-lso-pod-security.patch ../../files/ocs-ci/ocs-ci-12-skip-known-failures.patch ../../files/ocs-ci/ocs-ci-13-increase-timeout.patch ../../files/ocs-ci/ocs-ci-14-apply-icsp.patch ../../files/ocs-ci/ocs-ci-15-log-rotate.patch ../../files/ocs-ci/ocs-ci-16-nginx-fio-image.patch
ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /root/shilpi-rebase/ocs-ci.patch from /root/shilpi-rebase/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/ocs/resources/storage_cluster.py
checking file ocs_ci/ocs/resources/pod.py
checking file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
checking file ocs_ci/deployment/helpers/lso_helpers.py
checking file tests/functional/z_cluster/test_ceph_default_values_check.py
checking file tests/functional/z_cluster/test_must_gather.py
checking file tests/functional/object/mcg/test_s3_with_java_sdk.py
checking file tests/functional/object/mcg/test_noobaa_secret.py
checking file tests/functional/z_cluster/test_hugepages.py
checking file tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
checking file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
checking file tests/functional/object/mcg/test_mcg_resources_disruptions.py
checking file tests/functional/object/mcg/test_host_node_failure.py
checking file tests/functional/z_cluster/nodes/test_nodes_restart.py
checking file ocs_ci/helpers/helpers.py
checking file ocs_ci/utility/deployment.py
checking file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
checking file ocs_ci/templates/CSI/cephfs/pod.yaml
checking file ocs_ci/templates/CSI/rbd/pod.yaml
checking file ocs_ci/templates/app-pods/nginx.yaml
checking file ocs_ci/templates/app-pods/raw_block_pod.yaml
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/ocs/resources/storage_cluster.py
patching file ocs_ci/ocs/resources/pod.py
patching file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
patching file ocs_ci/deployment/helpers/lso_helpers.py
patching file tests/functional/z_cluster/test_ceph_default_values_check.py
patching file tests/functional/z_cluster/test_must_gather.py
patching file tests/functional/object/mcg/test_s3_with_java_sdk.py
patching file tests/functional/object/mcg/test_noobaa_secret.py
patching file tests/functional/z_cluster/test_hugepages.py
patching file tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
patching file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
patching file tests/functional/object/mcg/test_mcg_resources_disruptions.py
patching file tests/functional/object/mcg/test_host_node_failure.py
patching file tests/functional/z_cluster/nodes/test_nodes_restart.py
patching file ocs_ci/helpers/helpers.py
patching file ocs_ci/utility/deployment.py
patching file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
patching file ocs_ci/templates/CSI/cephfs/pod.yaml
patching file ocs_ci/templates/CSI/rbd/pod.yaml
patching file ocs_ci/templates/app-pods/nginx.yaml
patching file ocs_ci/templates/app-pods/raw_block_pod.yaml
Requirement already satisfied: pip in /root/shilpi-rebase/venv/lib/python3.9/site-packages (21.2.3)
Collecting pip
```