### PR TITLE
Made changes for 4.18 branch

### DIFF
--- a/files/ocs-ci/ocs-ci-00-ripsaw.patch
+++ b/files/ocs-ci/ocs-ci-00-ripsaw.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/benchmark_operator.py b/ocs_ci/ocs/benchmark_operator.py
-index 91c3df31..40c1f40f 100644
+index 3beda2000..1a6cfe6be 100644
 --- a/ocs_ci/ocs/benchmark_operator.py
 +++ b/ocs_ci/ocs/benchmark_operator.py
-@@ -120,6 +120,15 @@ class BenchmarkOperator(object):
+@@ -121,6 +121,15 @@ class BenchmarkOperator(object):
              log.info(f"Cloning {BMO_NAME} in {self.dir}")
              git_clone_cmd = f"git clone -b {self.branch} {self.repo} --depth 1"
              run(git_clone_cmd, shell=True, cwd=self.dir, check=True)
@@ -18,7 +18,7 @@ index 91c3df31..40c1f40f 100644
          except (CommandFailed, CalledProcessError) as cf:
              log.error(f"Error during cloning of {BMO_NAME} repository")
              raise cf
-@@ -150,7 +159,7 @@ class BenchmarkOperator(object):
+@@ -151,7 +160,7 @@ class BenchmarkOperator(object):
          """
          log.info("Deploy the benchmark-operator project")
          try:

--- a/files/ocs-ci/ocs-ci-01-strimzi.patch
+++ b/files/ocs-ci/ocs-ci-01-strimzi.patch
@@ -1,17 +1,17 @@
 diff --git a/ocs_ci/ocs/amq.py b/ocs_ci/ocs/amq.py
-index bbbed3d1..2dac6865 100644
+index 2d44f04f9..ffa6348cc 100644
 --- a/ocs_ci/ocs/amq.py
 +++ b/ocs_ci/ocs/amq.py
-@@ -26,7 +26,7 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check, validate_pv
+@@ -27,7 +27,7 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check, validate_pv
  from ocs_ci.ocs.resources.pvc import get_all_pvc_objs, delete_pvcs
- 
+
  log = logging.getLogger(__name__)
 -URL = "https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz"
 +URL = "https://get.helm.sh/helm-v2.16.1-linux-ppc64le.tar.gz"
  AMQ_BENCHMARK_NAMESPACE = "tiller"
- 
- 
-@@ -623,9 +623,9 @@ class AMQ(object):
+
+
+@@ -630,9 +630,9 @@ class AMQ(object):
          # Install helm cli (version v2.16.0 as we need tiller component)
          # And create tiller pods
          wget_cmd = f"wget -c --read-timeout=5 --tries=0 {URL}"
@@ -23,7 +23,7 @@ index bbbed3d1..2dac6865 100644
              f" --service-account {tiller_namespace}"
          )
          exec_cmd(cmd=wget_cmd, cwd=self.dir)
-@@ -647,7 +647,7 @@ class AMQ(object):
+@@ -654,7 +654,7 @@ class AMQ(object):
          values = templating.load_yaml(constants.AMQ_BENCHMARK_VALUE_YAML)
          values["numWorkers"] = num_of_clients
          benchmark_cmd = (
@@ -32,7 +32,41 @@ index bbbed3d1..2dac6865 100644
              f" --name {benchmark_pod_name} --tiller-namespace {tiller_namespace}"
          )
          exec_cmd(cmd=benchmark_cmd, cwd=self.dir)
-@@ -993,7 +993,7 @@ class AMQ(object):
+@@ -1000,7 +1000,7 @@ class AMQ(object):
+         if self.benchmark:
+             # Delete the helm app
+             try:
+-                purge_cmd = f"linux-amd64/helm delete benchmark --purge --tiller-namespace {tiller_namespace}"
++                purge_cmd = f"linux-ppc64le/helm delete benchmark --purge --tiller-namespace {tiller_namespace}"
+                 run(purge_cmd, shell=True, cwd=self.dir, check=True)
+             except (CommandFailed, CalledProcessError) as cf:
+                 log.error("Failed to delete help app")
+(END)
+ AMQ_BENCHMARK_NAMESPACE = "tiller"
+
+
+@@ -630,9 +630,9 @@ class AMQ(object):
+         # Install helm cli (version v2.16.0 as we need tiller component)
+         # And create tiller pods
+         wget_cmd = f"wget -c --read-timeout=5 --tries=0 {URL}"
+-        untar_cmd = "tar -zxvf helm-v2.16.1-linux-amd64.tar.gz"
++        untar_cmd = "tar -zxvf helm-v2.16.1-linux-ppc64le.tar.gz"
+         tiller_cmd = (
+-            f"linux-amd64/helm init --tiller-namespace {tiller_namespace}"
++            f"linux-ppc64le/helm init --tiller-namespace {tiller_namespace}"
+             f" --service-account {tiller_namespace}"
+         )
+         exec_cmd(cmd=wget_cmd, cwd=self.dir)
+@@ -654,7 +654,7 @@ class AMQ(object):
+         values = templating.load_yaml(constants.AMQ_BENCHMARK_VALUE_YAML)
+         values["numWorkers"] = num_of_clients
+         benchmark_cmd = (
+-            f"linux-amd64/helm install {constants.AMQ_BENCHMARK_POD_YAML}"
++            f"linux-ppc64le/helm install {constants.AMQ_BENCHMARK_POD_YAML}"
+             f" --name {benchmark_pod_name} --tiller-namespace {tiller_namespace}"
+         )
+         exec_cmd(cmd=benchmark_cmd, cwd=self.dir)
+@@ -1000,7 +1000,7 @@ class AMQ(object):
          if self.benchmark:
              # Delete the helm app
              try:

--- a/files/ocs-ci/ocs-ci-02-skipscaletest.patch
+++ b/files/ocs-ci/ocs-ci-02-skipscaletest.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py b/tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
-index 151f08fe..4f166b97 100644
+index dad91fd08..5298cbbad 100644
 --- a/tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
 +++ b/tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
 @@ -21,6 +21,7 @@ from ocs_ci.framework.pytest_customization.marks import (
@@ -8,10 +8,10 @@ index 151f08fe..4f166b97 100644
      skipif_aws_i3,
 +    skipif_ibm_power,
  )
-
-
-@@ -47,6 +48,7 @@ logger = logging.getLogger(__name__)
-     ],
+ 
+ 
+@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
+     "which created more PODs and failed for memory issue"
  )
  @skipif_aws_i3
 +@skipif_ibm_power

--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -126,7 +126,7 @@ index 4dcadbea..50d9c978 100644
  @pytest.mark.polarion_id("OCS-2594")
 
 diff --git a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
-index a5145d01..efa63099 100644
+index 8812511dc..db6616f31 100644
 --- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
 +++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
 @@ -21,6 +21,7 @@ from ocs_ci.framework.pytest_customization.marks import (
@@ -137,7 +137,7 @@ index a5145d01..efa63099 100644
      skipif_hci_client,
      brown_squad,
  )
-@@ -182,6 +183,7 @@ def delete_and_create_osd_node(osd_node_name):
+@@ -184,6 +185,7 @@ def delete_and_create_osd_node(osd_node_name):
  @skipif_managed_service
  @skipif_hci_provider_and_client
  @skipif_bmpsi
@@ -145,7 +145,7 @@ index a5145d01..efa63099 100644
  @skipif_external_mode
  class TestNodeReplacementWithIO(ManageTest):
      """
-@@ -261,6 +263,7 @@ class TestNodeReplacementWithIO(ManageTest):
+@@ -263,6 +265,7 @@ class TestNodeReplacementWithIO(ManageTest):
  @skipif_bmpsi
  @skipif_external_mode
  @skipif_ms_consumer
@@ -153,7 +153,7 @@ index a5145d01..efa63099 100644
  @skipif_hci_client
  class TestNodeReplacement(ManageTest):
      """
-@@ -309,6 +312,7 @@ class TestNodeReplacement(ManageTest):
+@@ -311,6 +314,7 @@ class TestNodeReplacement(ManageTest):
  @pytest.mark.polarion_id("OCS-2535")
  @skipif_external_mode
  @skipif_managed_service

--- a/files/ocs-ci/ocs-ci-04-skip-memoryleak.patch
+++ b/files/ocs-ci/ocs-ci-04-skip-memoryleak.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py b/tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
-index 42151749..cab68589 100644
+index 056b9ed79..69667a2d2 100644
 --- a/tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
 +++ b/tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
-@@ -14,7 +14,10 @@ from ocs_ci.helpers import helpers, disruption_helpers
+@@ -15,7 +15,10 @@ from ocs_ci.helpers import helpers, disruption_helpers
  from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
  from ocs_ci.framework.pytest_customization.marks import orange_squad
  from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
@@ -14,7 +14,7 @@ index 42151749..cab68589 100644
  from ocs_ci.ocs.exceptions import (
      PVCNotCreated,
      PodNotCreated,
-@@ -230,6 +233,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
+@@ -231,6 +234,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
  @orange_squad
  @scale
  @ignore_leftovers

--- a/files/ocs-ci/ocs-ci-05-drain.patch
+++ b/files/ocs-ci/ocs-ci-05-drain.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
-index 4b33bbb2..52712276 100644
+index bc24e26d2..b2688b2e3 100644
 --- a/ocs_ci/ocs/node.py
 +++ b/ocs_ci/ocs/node.py
-@@ -265,7 +265,7 @@ def drain_nodes(node_names, timeout=1800, disable_eviction=False):
+@@ -266,7 +266,7 @@ def drain_nodes(node_names, timeout=1800, disable_eviction=False):
          else:
              ocp.exec_oc_cmd(
                  f"adm drain {node_names_str} --force=true --ignore-daemonsets "
@@ -11,4 +11,3 @@ index 4b33bbb2..52712276 100644
                  timeout=timeout,
              )
      except TimeoutExpired:
-

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index 1b942b27..e659a317 100644
+index c87a69ea0..ff6c03bf7 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -2682,6 +2682,11 @@ def setup_persistent_monitoring():
+@@ -2776,6 +2776,11 @@ def setup_persistent_monitoring():
      https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation
      /4.16/html-single/managing_and_allocating_storage_resources/
      """
@@ -12,6 +12,5 @@ index 1b942b27..e659a317 100644
 +    )(interface_type=constants.CEPHBLOCKPOOL)
 +
      sc = helpers.default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
-
+ 
      # Get the list of monitoring pods
-

--- a/files/ocs-ci/ocs-ci-08-nodename-validation.patch
+++ b/files/ocs-ci/ocs-ci-08-nodename-validation.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/resources/storage_cluster.py b/ocs_ci/ocs/resources/storage_cluster.py
-index 2989ea74..67b0315e 100644
+index 50250c7e9..b8d1c2452 100644
 --- a/ocs_ci/ocs/resources/storage_cluster.py
 +++ b/ocs_ci/ocs/resources/storage_cluster.py
-@@ -583,7 +583,7 @@ def ocs_install_verification(
+@@ -584,7 +584,7 @@ def ocs_install_verification(
              deviceset_pvcs = list(set(deviceset_pvcs))
              if (
                  config.ENV_DATA.get("platform")
@@ -11,4 +11,3 @@ index 2989ea74..67b0315e 100644
                  or config.ENV_DATA.get("platform") == constants.AWS_PLATFORM
              ):
                  deviceset_pvcs = [
-

--- a/files/ocs-ci/ocs-ci-12-skip-known-failures.patch
+++ b/files/ocs-ci/ocs-ci-12-skip-known-failures.patch
@@ -154,7 +154,7 @@ index a2f706fb..a4e42259 100644
      """
      Test that there are appropriate alerts when NooBaa Bucket Quota is reached.
 diff --git a/tests/functional/object/mcg/test_mcg_resources_disruptions.py b/tests/functional/object/mcg/test_mcg_resources_disruptions.py
-index d4c5ee8a..92b15656 100644
+index 1cfd11667..dc58bacbb 100644
 --- a/tests/functional/object/mcg/test_mcg_resources_disruptions.py
 +++ b/tests/functional/object/mcg/test_mcg_resources_disruptions.py
 @@ -18,6 +18,7 @@ from ocs_ci.framework.testlib import (
@@ -180,7 +180,7 @@ index d4c5ee8a..92b15656 100644
              pytest.param(
                  *["noobaa_endpoint"], marks=pytest.mark.polarion_id("OCS-2288")
              ),
-@@ -231,6 +238,7 @@ class TestMCGResourcesDisruptions(MCGTest):
+@@ -233,6 +240,7 @@ class TestMCGResourcesDisruptions(MCGTest):
      @pytest.mark.polarion_id("OCS-2513")
      @marks.bugzilla("1903573")
      @skipif_managed_service
@@ -226,7 +226,7 @@ index c081a253..9769edfe 100644
          ],
      )
 diff --git a/tests/functional/z_cluster/nodes/test_nodes_restart.py b/tests/functional/z_cluster/nodes/test_nodes_restart.py
-index 5eb6f0b2..9bd95d6e 100644
+index 85164c671..23a9ece69 100644
 --- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
 +++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
 @@ -1,7 +1,7 @@
@@ -238,7 +238,7 @@ index 5eb6f0b2..9bd95d6e 100644
  from ocs_ci.framework.testlib import (
      tier4a,
      tier4b,
-@@ -140,6 +140,7 @@ class TestNodesRestart(ManageTest):
+@@ -141,6 +141,7 @@ class TestNodesRestart(ManageTest):
      )
      @skipif_ibm_cloud
      @skipif_vsphere_ipi

--- a/files/ocs-ci/ocs-ci-13-increase-timeout.patch
+++ b/files/ocs-ci/ocs-ci-13-increase-timeout.patch
@@ -1,13 +1,13 @@
 diff --git a/ocs_ci/helpers/helpers.py b/ocs_ci/helpers/helpers.py
-index febcee04..e9cd031a 100644
+index c03f840c4..c150aafc6 100644
 --- a/ocs_ci/helpers/helpers.py
 +++ b/ocs_ci/helpers/helpers.py
-@@ -100,7 +100,7 @@ def create_resource(do_reload=True, **kwargs):
+@@ -109,7 +109,7 @@ def create_resource(do_reload=True, **kwargs):
      return ocs_obj
-
-
+ 
+ 
 -def wait_for_resource_state(resource, state, timeout=60):
 +def wait_for_resource_state(resource, state, timeout=120):
      """
      Wait for a resource to get to a given status
-
+ 

--- a/files/ocs-ci/ocs-ci-14-apply-icsp.patch
+++ b/files/ocs-ci/ocs-ci-14-apply-icsp.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/utility/deployment.py b/ocs_ci/utility/deployment.py
-index 67bc5500..c5b101ee 100644
+index 2b009be74..f67da57a2 100644
 --- a/ocs_ci/utility/deployment.py
 +++ b/ocs_ci/utility/deployment.py
-@@ -139,7 +139,7 @@ def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
+@@ -141,7 +141,7 @@ def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
      pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
      create_directory_path(icsp_file_dest_dir)
      cmd = (
@@ -11,4 +11,3 @@ index 67bc5500..c5b101ee 100644
          f"{image} --confirm "
          f"--path {icsp_file_location}:{icsp_file_dest_dir}"
      )
-

--- a/files/ocs-ci/ocs-ci-15-log-rotate.patch
+++ b/files/ocs-ci/ocs-ci-15-log-rotate.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/functional/z_cluster/test_rook_ceph_log_rotate.py b/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
-index 6ae032d1..0a0a31e7 100644
+index 54195cc52..688a652ca 100644
 --- a/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
 +++ b/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
-@@ -94,7 +94,7 @@ class TestRookCephLogRotate(ManageTest):
+@@ -95,7 +95,7 @@ class TestRookCephLogRotate(ManageTest):
              else f"{self.podtype_id[pod_type][2]}{self.podtype_id[pod_type][1]}"
          )
          cnt_logs = len(re.findall(expected_string, output_cmd))

--- a/files/ocs-ci/ocs-ci-17-node-mantainance-skip.patch
+++ b/files/ocs-ci/ocs-ci-17-node-mantainance-skip.patch
@@ -1,17 +1,17 @@
 diff --git a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
-index 4752c928..a9363b1e 100644
+index 2b741b6a3..cbadbeab6 100644
 --- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
 +++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
 @@ -53,6 +53,9 @@ from ocs_ci.helpers.helpers import (
  )
  from ocs_ci.helpers import helpers
-
+ 
 +from ocs_ci.framework.pytest_customization.marks import (
 +    skipif_ibm_power,
 +)
-
+ 
  log = logging.getLogger(__name__)
-
+ 
 @@ -124,6 +127,7 @@ class TestNodesMaintenance(ManageTest):
      @tier1
      @skipif_managed_service
@@ -20,7 +20,7 @@ index 4752c928..a9363b1e 100644
      @pytest.mark.parametrize(
          argnames=["node_type"],
          argvalues=[
-@@ -192,6 +196,7 @@ class TestNodesMaintenance(ManageTest):
+@@ -195,6 +199,7 @@ class TestNodesMaintenance(ManageTest):
      @skipif_bm
      @skipif_managed_service
      @skipif_hci_provider_and_client
@@ -28,7 +28,7 @@ index 4752c928..a9363b1e 100644
      @pytest.mark.parametrize(
          argnames=["node_type"],
          argvalues=[
-@@ -468,6 +473,7 @@ class TestNodesMaintenance(ManageTest):
+@@ -474,6 +479,7 @@ class TestNodesMaintenance(ManageTest):
      @skipif_managed_service
      @skipif_hci_provider_and_client
      @skipif_more_than_three_workers
@@ -36,4 +36,3 @@ index 4752c928..a9363b1e 100644
      @pytest.mark.polarion_id("OCS-2524")
      @tier4a
      def test_pdb_check_simultaneous_node_drains(
-

--- a/files/ocs-ci/ocs-ci-18-test-replica-skip.patch
+++ b/files/ocs-ci/ocs-ci-18-test-replica-skip.patch
@@ -1,0 +1,23 @@
+diff --git a/tests/functional/storageclass/test_replica1.py b/tests/functional/storageclass/test_replica1.py
+index b30a6f23f..7cdbda218 100644
+--- a/tests/functional/storageclass/test_replica1.py
++++ b/tests/functional/storageclass/test_replica1.py
+@@ -40,7 +40,9 @@ from ocs_ci.ocs.replica_one import (
+     get_all_osd_names_by_device_class,
+     get_failure_domains,
+ )
+-
++from ocs_ci.framework.pytest_customization.marks import (
++    skipif_ibm_power,
++)
+ 
+ log = getLogger(__name__)
+ 
+@@ -72,6 +74,7 @@ def create_pod_on_failure_domain(project_factory, pod_factory, failure_domain: s
+ @brown_squad
+ @bugzilla("2274175")
+ @tier1
++@skipif_ibm_power
+ @skipif_external_mode
+ class TestReplicaOne:
+     @pytest.fixture(scope="class")


### PR DESCRIPTION
**Setup script after changing patch files**
Created new patch file for skipping test files/ocs-ci/ocs-ci-18-test-replica-skip.patch due to issue https://github.com/red-hat-storage/ocs-ci/issues/10706
```
~/ocs-upi-kvm/src/ocs-ci ~/ocs-upi-kvm/scripts
patchfiles=../../files/ocs-ci/ocs-ci-00-ripsaw.patch ../../files/ocs-ci/ocs-ci-01-strimzi.patch ../../files/ocs-ci/ocs-ci-02-skipscaletest.patch ../../files/ocs-ci/ocs-ci-03-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-04-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-05-drain.patch ../../files/ocs-ci/ocs-ci-06-check-sc-exists.patch ../../files/ocs-ci/ocs-ci-07-kafka-drop.patch ../../files/ocs-ci/ocs-ci-08-nodename-validation.patch ../../files/ocs-ci/ocs-ci-10-logwriter.patch ../../files/ocs-ci/ocs-ci-11-lso-pod-security.patch ../../files/ocs-ci/ocs-ci-12-skip-known-failures.patch ../../files/ocs-ci/ocs-ci-13-increase-timeout.patch ../../files/ocs-ci/ocs-ci-14-apply-icsp.patch ../../files/ocs-ci/ocs-ci-15-log-rotate.patch ../../files/ocs-ci/ocs-ci-16-nginx-fio-image.patch ../../files/ocs-ci/ocs-ci-17-node-mantainance-skip.patch ../../files/ocs-ci/ocs-ci-18-test-replica-skip.patch
ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /root/ocs-ci.patch from /root/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/ocs/resources/storage_cluster.py
checking file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
checking file ocs_ci/deployment/helpers/lso_helpers.py
checking file tests/functional/z_cluster/test_ceph_default_values_check.py
checking file tests/functional/z_cluster/test_must_gather.py
checking file tests/functional/object/mcg/test_s3_with_java_sdk.py
checking file tests/functional/object/mcg/test_noobaa_secret.py
checking file tests/functional/z_cluster/test_hugepages.py
checking file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
checking file tests/functional/object/mcg/test_mcg_resources_disruptions.py
checking file tests/functional/object/mcg/test_host_node_failure.py
checking file tests/functional/z_cluster/nodes/test_nodes_restart.py
checking file ocs_ci/helpers/helpers.py
checking file ocs_ci/utility/deployment.py
checking file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
checking file ocs_ci/templates/CSI/cephfs/pod.yaml
checking file ocs_ci/templates/CSI/rbd/pod.yaml
checking file ocs_ci/templates/app-pods/nginx.yaml
checking file ocs_ci/templates/app-pods/raw_block_pod.yaml
checking file tests/functional/z_cluster/nodes/test_nodes_maintenance.py
checking file tests/functional/storageclass/test_replica1.py
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/ocs/resources/storage_cluster.py
patching file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
patching file ocs_ci/deployment/helpers/lso_helpers.py
patching file tests/functional/z_cluster/test_ceph_default_values_check.py
patching file tests/functional/z_cluster/test_must_gather.py
patching file tests/functional/object/mcg/test_s3_with_java_sdk.py
patching file tests/functional/object/mcg/test_noobaa_secret.py
patching file tests/functional/z_cluster/test_hugepages.py
patching file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
patching file tests/functional/object/mcg/test_mcg_resources_disruptions.py
patching file tests/functional/object/mcg/test_host_node_failure.py
patching file tests/functional/z_cluster/nodes/test_nodes_restart.py
patching file ocs_ci/helpers/helpers.py
patching file ocs_ci/utility/deployment.py
patching file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
patching file ocs_ci/templates/CSI/cephfs/pod.yaml
patching file ocs_ci/templates/CSI/rbd/pod.yaml
patching file ocs_ci/templates/app-pods/nginx.yaml
patching file ocs_ci/templates/app-pods/raw_block_pod.yaml
patching file tests/functional/z_cluster/nodes/test_nodes_maintenance.py
patching file tests/functional/storageclass/test_replica1.py
Requirement already satisfied: pip in /root/venv/lib/python3.9/site-packages (21.2.3)
Collecting pip
  Using cached pip-25.0-py3-none-any.whl (1.8 MB)
Collecting setuptools==63.2.0
  Using cached setuptools-63.2.0-py3-none-any.whl (1.2 MB)
Collecting wheel
  Using cached wheel-0.45.1-py3-none-any.whl (72 kB)
Collecting Cython==3.0.0a10
  Using cached Cython-3.0.0a10-py2.py3-none-any.whl (1.1 MB)
Installing collected packages: wheel, setuptools, pip, Cython
  Attempting uninstall: setuptools
    Found existing installation: setuptools 53.0.0
    Uninstalling setuptools-53.0.0:
      Successfully uninstalled setuptools-53.0.0
  Attempting uninstall: pip
    Found existing installation: pip 21.2.3
    Uninstalling pip-21.2.3:
```