### PR TITLE
Adding script for installing kubectl-rook-ceph plugin

### DIFF
--- a/files/ocs-ci/ocs-ci-19-rook-ceph-plugin.patch
+++ b/files/ocs-ci/ocs-ci-19-rook-ceph-plugin.patch
@@ -1,0 +1,59 @@
+diff --git a/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh b/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh
+index 6cbbe1862..aa49185b2 100644
+--- a/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh
++++ b/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh
+@@ -1,4 +1,10 @@
+-oc krew install rook-ceph
++arch=$(uname -i)
++if [[ "$arch" == ppc64le ]]
++then
++ cp /root/kubectl-rook-ceph/bin/kubectl-rook-ceph /usr/local/bin/
++else
++ oc krew install rook-ceph
++fi
+ host=$(hostname)
+ if [[ "$host" == *"jagent"* ]]
+ then
+diff --git a/ocs_ci/ocs/ceph_debug.py b/ocs_ci/ocs/ceph_debug.py
+index a294ed3bd..e257dd9f1 100644
+--- a/ocs_ci/ocs/ceph_debug.py
++++ b/ocs_ci/ocs/ceph_debug.py
+@@ -33,7 +33,8 @@ class RookCephPlugin(object):
+         self.namespace = namespace
+         self.operator_namespace = operator_namespace
+         self.alternate_image = alternate_image
+-        self.cmd = f"rook-ceph -n {namespace} --operator-namespace {operator_namespace}"
++        #self.cmd = f"rook-ceph -n {namespace} --operator-namespace {operator_namespace}"
++        self.cmd = f"kubectl-rook-ceph -n {namespace}"
+         self.deployment_in_maintenance = dict()
+ 
+         if not self.check_krew_installed():
+@@ -82,7 +83,7 @@ class RookCephPlugin(object):
+         """
+         installed = True
+         try:
+-            exec_cmd(cmd="kubectl rook-ceph --help")
++            exec_cmd(cmd="kubectl-rook-ceph --help")
+         except Exception as ex:
+             if 'unknown command "rook-ceph" for "kubectl"' in ex.args[0]:
+                 installed = False
+@@ -127,7 +128,8 @@ class RookCephPlugin(object):
+         if alternate_image:
+             self.alternate_image = alternate_image
+             command += f" --alternate-image {self.alternate_image}"
+-        OCP().exec_oc_cmd(command=command, timeout=timeout, out_yaml_format=False)
++        #OCP().exec_oc_cmd(command=command, timeout=timeout, out_yaml_format=False)
++        exec_cmd(cmd=command, timeout=timeout)
+         logger.info(f"{deployment_name} is successfully in mainetenance mode now!")
+ 
+         self.deployment_in_maintenance[deployment_name] = True
+@@ -154,7 +156,8 @@ class RookCephPlugin(object):
+         if alternate_image:
+             self.alternate_image = alternate_image
+             command += f" --alternate-image {self.alternate_image}"
+-        OCP().exec_oc_cmd(command=command, timeout=timeout, out_yaml_format=False)
++        #OCP().exec_oc_cmd(command=command, timeout=timeout, out_yaml_format=False)
++        exec_cmd(cmd=command, timeout=timeout)
+         logger.info(
+             f"{deployment_name} is successfully removed from mainetenance mode now!"
+         )

--- a/scripts/helper/rook-ceph-plugin.sh
+++ b/scripts/helper/rook-ceph-plugin.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+
+if [ -e /usr/local/go/bin/go ]; then
+      echo "Go binary is already installed, hence exporting the path."
+      export PATH=/usr/local/go/bin:$PATH
+else
+      echo "Go binary not found. Installing Go..."
+      ARCH=`arch`
+      [ "$ARCH" == "x86_64" ] && ARCH="amd64"
+      VERSION="${GO_VERSION:-$(curl -s https://go.dev/dl/?mode=json | jq -r '.[0].version')}"
+      wget https://golang.org/dl/"${VERSION}".linux-"${ARCH}".tar.gz
+      rm -rf /usr/local/go && tar -C /usr/local -xvzf "${VERSION}".linux-"${ARCH}".tar.gz
+      export PATH=/usr/local/go/bin:$PATH
+fi
+
+echo -e "\n Cloning kubectl-rook-ceph repository...\n"
+
+git clone https://github.com/rook/kubectl-rook-ceph.git
+cd kubectl-rook-ceph/ && make build
+./bin/kubectl-rook-ceph --help
+
+echo -e "\n Kubectl Rook Ceph Plugin installed Successfully"
+
+oc get namespace/openshift-storage > /dev/null 2>&1
+if [ "$?" == 0 ]; then
+	./bin/kubectl-rook-ceph -n openshift-storage rook version
+	exit 1
+fi


### PR DESCRIPTION
These changes will install kubectl-rook-ceph plugin and also updates ocs-ci code for using installed plugin.
These changes are required as 2 of the tier2 tests (`tests/cross_functional/kcs/test_maintenance_pod.py::TestMaintenancePod::test_maintenance_pod_for_osd` ; 
`tests/cross_functional/kcs/test_maintenance_pod.py::TestMaintenancePod::test_maintenance_pod_for_mons`) are failing without these changes. 