### PR TITLE
Fixing jenkins job

### DIFF
--- a/scripts/helper/rook-ceph-plugin.sh
+++ b/scripts/helper/rook-ceph-plugin.sh
@@ -25,7 +25,10 @@ cd kubectl-rook-ceph/ && make build
 
 echo -e "\n Kubectl Rook Ceph Plugin installed Successfully"
 
+set +e
+
 oc get namespace/openshift-storage > /dev/null 2>&1
+
 if [ "$?" == 0 ]; then
 	./bin/kubectl-rook-ceph -n openshift-storage rook version
 else


### PR DESCRIPTION
This will fix jenkins job as rook-ceph-plugin.sh script is terminating at `oc get namespace/openshift-storage > /dev/null 2>&1` as set -e is present at the top of the script. 