### PR TITLE
copying kubectl-rook-ceph-binary to bin

### DIFF
--- a/files/ocs-ci/ocs-ci-19-rook-ceph-plugin.patch
+++ b/files/ocs-ci/ocs-ci-19-rook-ceph-plugin.patch
@@ -1,19 +1,3 @@
-diff --git a/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh b/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh
-index 6cbbe1862..aa49185b2 100644
---- a/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh
-+++ b/ocs_ci/templates/krew_plugin/rookcephplugin_install.sh
-@@ -1,4 +1,10 @@
--oc krew install rook-ceph
-+arch=$(uname -i)
-+if [[ "$arch" == ppc64le ]]
-+then
-+ cp /root/kubectl-rook-ceph/bin/kubectl-rook-ceph /usr/local/bin/
-+else
-+ oc krew install rook-ceph
-+fi
- host=$(hostname)
- if [[ "$host" == *"jagent"* ]]
- then
 diff --git a/ocs_ci/ocs/ceph_debug.py b/ocs_ci/ocs/ceph_debug.py
 index a294ed3bd..e257dd9f1 100644
 --- a/ocs_ci/ocs/ceph_debug.py

--- a/scripts/helper/rook-ceph-plugin.sh
+++ b/scripts/helper/rook-ceph-plugin.sh
@@ -22,6 +22,7 @@ echo -e "\n Cloning kubectl-rook-ceph repository...\n"
 git clone https://github.com/rook/kubectl-rook-ceph.git
 cd kubectl-rook-ceph/ && make build
 ./bin/kubectl-rook-ceph --help
+cp bin/kubectl-rook-ceph /usr/local/bin/
 
 echo -e "\n Kubectl Rook Ceph Plugin installed Successfully"
 
@@ -30,7 +31,7 @@ set +e
 oc get namespace/openshift-storage > /dev/null 2>&1
 
 if [ "$?" == 0 ]; then
-	./bin/kubectl-rook-ceph -n openshift-storage rook version
+	kubectl-rook-ceph -n openshift-storage rook version
 else
        echo -e "\n Rook version can't be checked as Openshift-storage namespace doesn't exist.."
 fi


### PR DESCRIPTION
Copying kubectl-rook-ceph binary into bin while installing it, instead of  copying it while running tests. 