### PR TITLE
Making changes for 4.19 rebase

### DIFF
--- a/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
+++ b/files/ocs-ci/ocs-ci-03-addcapacity-skip.patch
@@ -65,18 +65,18 @@ index 62152e78..7729cb8e 100644
  @tier4c
  class TestAddCapacityWithResourceDelete:
 diff --git a/tests/functional/z_cluster/cluster_expansion/test_node_expansion.py b/tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
-index 2c0b143a..e59f101a 100644
+index f829c218f..201d8c379 100644
 --- a/tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
 +++ b/tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
-@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
+@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
      skipif_ibm_flash,
      skipif_managed_service,
      skipif_hci_provider_and_client,
 +    skipif_ibm_power,
      brown_squad,
  )
-
-@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
+ from ocs_ci.ocs.resources.storage_cluster import (
+@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
  @skipif_hci_provider_and_client
  @skipif_flexy_deployment
  @skipif_ibm_flash
@@ -126,7 +126,7 @@ index 4dcadbea..50d9c978 100644
  @pytest.mark.polarion_id("OCS-2594")
 
 diff --git a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
-index 8812511dc..db6616f31 100644
+index 2ea2f825c..46f426c13 100644
 --- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
 +++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
 @@ -21,6 +21,7 @@ from ocs_ci.framework.pytest_customization.marks import (
@@ -136,8 +136,8 @@ index 8812511dc..db6616f31 100644
 +    skipif_ibm_power,
      skipif_hci_client,
      brown_squad,
- )
-@@ -184,6 +185,7 @@ def delete_and_create_osd_node(osd_node_name):
+     skipif_ibm_cloud_managed,
+@@ -191,6 +192,7 @@ def delete_and_create_osd_node(osd_node_name):
  @skipif_managed_service
  @skipif_hci_provider_and_client
  @skipif_bmpsi
@@ -145,7 +145,7 @@ index 8812511dc..db6616f31 100644
  @skipif_external_mode
  class TestNodeReplacementWithIO(ManageTest):
      """
-@@ -263,6 +265,7 @@ class TestNodeReplacementWithIO(ManageTest):
+@@ -275,6 +277,7 @@ class TestNodeReplacementWithIO(ManageTest):
  @skipif_bmpsi
  @skipif_external_mode
  @skipif_ms_consumer
@@ -153,7 +153,7 @@ index 8812511dc..db6616f31 100644
  @skipif_hci_client
  class TestNodeReplacement(ManageTest):
      """
-@@ -311,6 +314,7 @@ class TestNodeReplacement(ManageTest):
+@@ -329,6 +332,7 @@ class TestNodeReplacement(ManageTest):
  @pytest.mark.polarion_id("OCS-2535")
  @skipif_external_mode
  @skipif_managed_service

--- a/files/ocs-ci/ocs-ci-05-drain.patch
+++ b/files/ocs-ci/ocs-ci-05-drain.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/node.py b/ocs_ci/ocs/node.py
-index bc24e26d2..b2688b2e3 100644
+index a2998ca1f..ed0320db7 100644
 --- a/ocs_ci/ocs/node.py
 +++ b/ocs_ci/ocs/node.py
-@@ -266,7 +266,7 @@ def drain_nodes(node_names, timeout=1800, disable_eviction=False):
+@@ -267,7 +267,7 @@ def drain_nodes(node_names, timeout=1800, disable_eviction=False):
          else:
              ocp.exec_oc_cmd(
                  f"adm drain {node_names_str} --force=true --ignore-daemonsets "

--- a/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
+++ b/files/ocs-ci/ocs-ci-06-check-sc-exists.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/deployment/deployment.py b/ocs_ci/deployment/deployment.py
-index c87a69ea0..ff6c03bf7 100644
+index 2c420b756..262bd6ad7 100644
 --- a/ocs_ci/deployment/deployment.py
 +++ b/ocs_ci/deployment/deployment.py
-@@ -2776,6 +2776,11 @@ def setup_persistent_monitoring():
+@@ -2822,6 +2822,11 @@ def setup_persistent_monitoring():
      https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation
      /4.16/html-single/managing_and_allocating_storage_resources/
      """

--- a/files/ocs-ci/ocs-ci-08-nodename-validation.patch
+++ b/files/ocs-ci/ocs-ci-08-nodename-validation.patch
@@ -1,8 +1,8 @@
 diff --git a/ocs_ci/ocs/resources/storage_cluster.py b/ocs_ci/ocs/resources/storage_cluster.py
-index 50250c7e9..b8d1c2452 100644
+index 74ee69718..d1eaae22f 100644
 --- a/ocs_ci/ocs/resources/storage_cluster.py
 +++ b/ocs_ci/ocs/resources/storage_cluster.py
-@@ -584,7 +584,7 @@ def ocs_install_verification(
+@@ -598,7 +598,7 @@ def ocs_install_verification(
              deviceset_pvcs = list(set(deviceset_pvcs))
              if (
                  config.ENV_DATA.get("platform")

--- a/files/ocs-ci/ocs-ci-09-scipy-numpy.patch
+++ b/files/ocs-ci/ocs-ci-09-scipy-numpy.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index 8ef9aa261..fb69792ef 100644
+--- a/setup.py
++++ b/setup.py
+@@ -48,11 +48,11 @@ setup(
+         "google-cloud-storage==2.6.0",
+         "google-auth==2.14.1",
+         "elasticsearch==8.11.1",
+-        "numpy==1.23.2",
++        "numpy==1.26.4",
+         "pandas==1.5.2",
+         "tabulate==0.9.0",
+         "python-ipmi==0.4.2",
+-        "scipy==1.12.0",
++        "scipy==1.11.0",
+         "PrettyTable==0.7.2",
+         "azure-common==1.1.28",
+         "azure-mgmt-compute==33.0.0",

--- a/files/ocs-ci/ocs-ci-12-skip-known-failures.patch
+++ b/files/ocs-ci/ocs-ci-12-skip-known-failures.patch
@@ -67,7 +67,7 @@ index 729d3c04..775c5d0c 100644
  class TestS3WithJavaSDK:
      @bugzilla("2064304")
 diff --git a/tests/functional/object/mcg/test_noobaa_secret.py b/tests/functional/object/mcg/test_noobaa_secret.py
-index d149e307..eb1af5a9 100644
+index 0e20e5261..17d999c40 100644
 --- a/tests/functional/object/mcg/test_noobaa_secret.py
 +++ b/tests/functional/object/mcg/test_noobaa_secret.py
 @@ -21,6 +21,7 @@ from ocs_ci.framework.pytest_customization.marks import (
@@ -78,7 +78,7 @@ index d149e307..eb1af5a9 100644
      red_squad,
      runs_on_provider,
      mcg,
-@@ -185,6 +186,7 @@ class TestNoobaaSecrets:
+@@ -188,6 +189,7 @@ class TestNoobaaSecrets:
 
      @bugzilla("2090956")
      @bugzilla("1992090")

--- a/samples/cron/test-cron-ocs.sh
+++ b/samples/cron/test-cron-ocs.sh
@@ -17,8 +17,8 @@ export PLATFORM=${PLATFORM:="kvm"}                              # Also supported
 # These environment variables are optional, but should be set for cron jobs,
 # so that CLUSTER_ID_PREFIX below is properly initialized for powervs.
 
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 
 
 # These are optional for KVM OCP cluster create.  Default values are shown

--- a/samples/dev-ocs-fio.sh
+++ b/samples/dev-ocs-fio.sh
@@ -16,8 +16,8 @@ export PLATFORM=${PLATFORM:=powervs}                            # Only powervs a
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 
 # These are optional and apply only to kvm and powervs for now. They are presently ignored on powervm
 

--- a/samples/dev-ocs-perf.sh
+++ b/samples/dev-ocs-perf.sh
@@ -32,8 +32,8 @@ export PLATFORM=${PLATFORM:=powervs}                            # Only powervs a
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 
 # These are optional and apply only to kvm and powervs for now.  They are presently ignored on powervm
 

--- a/samples/dev-ocs.sh
+++ b/samples/dev-ocs.sh
@@ -16,8 +16,8 @@ export PLATFORM=${PLATFORM:="kvm"}                              # Also supported
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 
 # These are optional for KVM OCP cluster create.  Default values are shown
 

--- a/samples/powervs-test-ocs.sh
+++ b/samples/powervs-test-ocs.sh
@@ -5,8 +5,8 @@
 export PLATFORM=powervs # Supports powervs only
 #export RHID_USERNAME=<your rh subscription id>
 #export RHID_PASSWORD=<your rh subscription password>
-export OCP_VERSION=${OCP_VERSION:=4.18} # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19} # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 #export PVS_API_KEY=<your key>
 #export FIPS_ENABLEMENT=false
 # These are optional for PowerVS OCP cluster create.  Default values are shown

--- a/samples/test-ocs-perf.sh
+++ b/samples/test-ocs-perf.sh
@@ -32,8 +32,8 @@ export PLATFORM=${PLATFORM:=powervs}                            # Only powervs a
 
 # These environment variables are optional for all platforms
 #export FIPS_ENABLEMENT=false
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 
 # These are optional and apply only to kvm and powervs.  They are presently ignored on powervm
 

--- a/samples/test-ocs.sh
+++ b/samples/test-ocs.sh
@@ -16,8 +16,8 @@ export PLATFORM=${PLATFORM:="kvm"}                              # Also supported
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 
 
 # These are optional for KVM OCP cluster create.  Default values are shown

--- a/samples/upgrade-ocs.sh
+++ b/samples/upgrade-ocs.sh
@@ -22,8 +22,8 @@ export PLATFORM=${PLATFORM:="powervs"}                          # Also supported
 
 # These environment variables are optional for all platforms
 
-export OCP_VERSION=${OCP_VERSION:=4.18}                          # 4.12-4.18 are supported
-export OCS_VERSION=${OCS_VERSION:=4.18}
+export OCP_VERSION=${OCP_VERSION:=4.19}                          # 4.12-4.19 are supported
+export OCS_VERSION=${OCS_VERSION:=4.19}
 #export FIPS_ENABLEMENT=false
 # These are optional for KVM OCP cluster create.  Default values are shown
 

--- a/scripts/helper/create-cluster.sh
+++ b/scripts/helper/create-cluster.sh
@@ -28,8 +28,8 @@ case "$OCP_VERSION" in
                 fi
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;
-	    4.14)
-                OCP_RELEASE="4.14.38"
+	4.14)
+                OCP_RELEASE="4.14.48"
                 RHCOS_VERSION="4.14"
                 if [ -z "$RHCOS_RELEASE" ]; then
                         RHCOS_RELEASE="4.14.34"                   # Latest release of RHCOS 4.14 at this time
@@ -37,39 +37,46 @@ case "$OCP_VERSION" in
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;
         4.15)
-                OCP_RELEASE="4.15.36"
+                OCP_RELEASE="4.15.46"
                 RHCOS_VERSION="4.15"
                 if [ -z "$RHCOS_RELEASE" ]; then
-                        RHCOS_RELEASE="4.15.23"                   # Latest release of RHCOS 4.14 at this time
+                        RHCOS_RELEASE="4.15.23"                   # Latest release of RHCOS 4.15 at this time
                 fi
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;	
         4.16)
-                OCP_RELEASE="4.16.17"
+                OCP_RELEASE="4.16.36"
                 RHCOS_VERSION="4.16"
                 if [ -z "$RHCOS_RELEASE" ]; then
-                        RHCOS_RELEASE="4.16.3"                   # Latest release of RHCOS 4.14 at this time
+                        RHCOS_RELEASE="4.16.36"                   # Latest release of RHCOS 4.16 at this time
                 fi
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;
 		
-		4.17)
-                OCP_RELEASE="4.17.1"
+	4.17)
+                OCP_RELEASE="4.17.18"
                 RHCOS_VERSION="4.17"
                 if [ -z "$RHCOS_RELEASE" ]; then
-                        RHCOS_RELEASE="4.17.0"                   # Latest release of RHCOS 4.14 at this time
+                        RHCOS_RELEASE="4.17.17"                   # Latest release of RHCOS 4.17 at this time
                 fi
                 RHCOS_SUFFIX="-$RHCOS_RELEASE"
                 ;;
-
-	    4.18)
-                unset OCP_RELEASE
+        4.18)
+                OCP_RELEASE="4.18.1"
                 RHCOS_VERSION="4.18"
+                if [ -z "$RHCOS_RELEASE" ]; then
+                        RHCOS_RELEASE="4.18.1"                   # Latest release of RHCOS 4.18 at this time
+                fi
+                RHCOS_SUFFIX="-$RHCOS_RELEASE"
+                ;;
+	4.19)
+                unset OCP_RELEASE
+                RHCOS_VERSION="4.19"
                 unset RHCOS_RELEASE
                 RHCOS_SUFFIX="-$RHCOS_VERSION"
                 ;;	
 	*)
-		echo "Invalid OCP_VERSION=$OCP_VERSION.  Supported versions are 4.12 - 4.18"
+		echo "Invalid OCP_VERSION=$OCP_VERSION.  Supported versions are 4.12 - 4.19"
 		exit 1
 esac
 

--- a/scripts/helper/parameters.sh
+++ b/scripts/helper/parameters.sh
@@ -12,9 +12,9 @@ export RHID_KEY=${RHID_KEY:=""}
 
 export PLATFORM=${PLATFORM:="kvm"}
 
-export OCP_VERSION=${OCP_VERSION:="4.18"}
+export OCP_VERSION=${OCP_VERSION:="4.19"}
 
-export OCS_VERSION=${OCS_VERSION:="4.18"}
+export OCS_VERSION=${OCS_VERSION:="4.19"}
 export OCS_REGISTRY_IMAGE=${OCS_REGISTRY_IMAGE:="quay.io/rhceph-dev/ocs-registry:latest-stable-$OCS_VERSION"}
 export OPTIONAL_OPERATORS_IMAGE=${OPTIONAL_OPERATORS_IMAGE:="quay.io/openshift-release-dev/ocp-release-nightly:iib-int-index-art-operators-$OCP_VERSION"}
 


### PR DESCRIPTION
Setup script output
```
patchfiles=../../files/ocs-ci/ocs-ci-00-ripsaw.patch ../../files/ocs-ci/ocs-ci-01-strimzi.patch ../../files/ocs-ci/ocs-ci-02-skipscaletest.patch ../../files/ocs-ci/ocs-ci-03-addcapacity-skip.patch ../../files/ocs-ci/ocs-ci-04-skip-memoryleak.patch ../../files/ocs-ci/ocs-ci-05-drain.patch ../../files/ocs-ci/ocs-ci-06-check-sc-exists.patch ../../files/ocs-ci/ocs-ci-07-kafka-drop.patch ../../files/ocs-ci/ocs-ci-08-nodename-validation.patch ../../files/ocs-ci/ocs-ci-09-scypi-numpy.patch ../../files/ocs-ci/ocs-ci-10-logwriter.patch ../../files/ocs-ci/ocs-ci-11-lso-pod-security.patch ../../files/ocs-ci/ocs-ci-12-skip-known-failures.patch ../../files/ocs-ci/ocs-ci-13-increase-timeout.patch ../../files/ocs-ci/ocs-ci-14-apply-icsp.patch ../../files/ocs-ci/ocs-ci-15-log-rotate.patch ../../files/ocs-ci/ocs-ci-16-nginx-fio-image.patch ../../files/ocs-ci/ocs-ci-17-node-mantainance-skip.patch ../../files/ocs-ci/ocs-ci-18-test-replica-skip.patch ../../files/ocs-ci/ocs-ci-19-rook-ceph-plugin.patch
ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /root/ocs-ci.patch from /root/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/ocs/resources/storage_cluster.py
checking file setup.py
checking file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
checking file ocs_ci/deployment/helpers/lso_helpers.py
checking file tests/functional/z_cluster/test_ceph_default_values_check.py
checking file tests/functional/z_cluster/test_must_gather.py
checking file tests/functional/object/mcg/test_s3_with_java_sdk.py
checking file tests/functional/object/mcg/test_noobaa_secret.py
checking file tests/functional/z_cluster/test_hugepages.py
checking file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
checking file tests/functional/object/mcg/test_mcg_resources_disruptions.py
checking file tests/functional/object/mcg/test_host_node_failure.py
checking file tests/functional/z_cluster/nodes/test_nodes_restart.py
checking file ocs_ci/helpers/helpers.py
checking file ocs_ci/utility/deployment.py
checking file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
checking file ocs_ci/templates/CSI/cephfs/pod.yaml
checking file ocs_ci/templates/CSI/rbd/pod.yaml
checking file ocs_ci/templates/app-pods/nginx.yaml
checking file ocs_ci/templates/app-pods/raw_block_pod.yaml
checking file tests/functional/z_cluster/nodes/test_nodes_maintenance.py
checking file tests/functional/storageclass/test_replica1.py
checking file ocs_ci/ocs/ceph_debug.py
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/ocs/resources/storage_cluster.py
patching file setup.py
patching file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
patching file ocs_ci/deployment/helpers/lso_helpers.py
patching file tests/functional/z_cluster/test_ceph_default_values_check.py
patching file tests/functional/z_cluster/test_must_gather.py
patching file tests/functional/object/mcg/test_s3_with_java_sdk.py
patching file tests/functional/object/mcg/test_noobaa_secret.py
patching file tests/functional/z_cluster/test_hugepages.py
patching file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
patching file tests/functional/object/mcg/test_mcg_resources_disruptions.py
patching file tests/functional/object/mcg/test_host_node_failure.py
patching file tests/functional/z_cluster/nodes/test_nodes_restart.py
patching file ocs_ci/helpers/helpers.py
patching file ocs_ci/utility/deployment.py
patching file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
patching file ocs_ci/templates/CSI/cephfs/pod.yaml
patching file ocs_ci/templates/CSI/rbd/pod.yaml
patching file ocs_ci/templates/app-pods/nginx.yaml
patching file ocs_ci/templates/app-pods/raw_block_pod.yaml
patching file tests/functional/z_cluster/nodes/test_nodes_maintenance.py
patching file tests/functional/storageclass/test_replica1.py
patching file ocs_ci/ocs/ceph_debug.py
Requirement already satisfied: pip in /root/venv/lib/python3.9/site-packages (21.2.3)
Collecting pip
  Using cached pip-25.0.1-py3-none-any.whl (1.8 MB)
Collecting setuptools==63.2.0
  Using cached setuptools-63.2.0-py3-none-any.whl (1.2 MB)
Collecting wheel
  Using cached wheel-0.45.1-py3-none-any.whl (72 kB)
Collecting Cython==3.0.0a10
  Using cached Cython-3.0.0a10-py2.py3-none-any.whl (1.1 MB)
Installing collected packages: wheel, setuptools, pip, Cython
  Attempting uninstall: setuptools
    Found existing installation: setuptools 53.0.0
    Uninstalling setuptools-53.0.0:
      Successfully uninstalled setuptools-53.0.0
  Attempting uninstall: pip
    Found existing installation: pip 21.2.3

