### PR TITLE
updating sequence of setting sc as default

### DIFF
--- a/files/ocs-ci/ocs-ci-20-tier2-default-sc.patch
+++ b/files/ocs-ci/ocs-ci-20-tier2-default-sc.patch
@@ -1,0 +1,38 @@
+diff --git a/ocs_ci/helpers/helpers.py b/ocs_ci/helpers/helpers.py
+index 9554ba0cd..3bd2b5a48 100644
+--- a/ocs_ci/helpers/helpers.py
++++ b/ocs_ci/helpers/helpers.py
+@@ -1953,6 +1953,16 @@ def change_default_storageclass(scname):
+     """
+     default_sc = get_default_storage_class()
+     ocp_obj = ocp.OCP(kind="StorageClass")
++
++    # Change the new storageclass to default
++    patch = (
++        ' \'{"metadata": {"annotations":'
++        '{"storageclass.kubernetes.io/is-default-class"'
++        ':"true"}}}\' '
++    )
++    patch_cmd = f"patch storageclass {scname} -p" + patch
++    ocp_obj.exec_oc_cmd(command=patch_cmd)
++
+     if default_sc:
+         # Change the existing default Storageclass annotation to false
+         for sc in default_sc:
+@@ -1964,16 +1974,6 @@ def change_default_storageclass(scname):
+             patch_cmd = f"patch storageclass {sc} -p" + patch
+             ocp_obj.exec_oc_cmd(command=patch_cmd)
+ 
+-    # Change the new storageclass to default
+-    patch = (
+-        ' \'{"metadata": {"annotations":'
+-        '{"storageclass.kubernetes.io/is-default-class"'
+-        ':"true"}}}\' '
+-    )
+-    patch_cmd = f"patch storageclass {scname} -p" + patch
+-    ocp_obj.exec_oc_cmd(command=patch_cmd)
+-    return True
+-
+ 
+ def is_volume_present_in_backend(interface, image_uuid, pool_name=None):
+     """


### PR DESCRIPTION
Currently some of the tier2 tests are failing because of Assertion error: 
```
        # Change the above created StorageClass to default
        log.info(f"Changing the default StorageClass to {sc_obj.name}")
        helpers.change_default_storageclass(scname=sc_obj.name)
        # Confirm that the default StorageClass is changed
        tmp_default_sc = helpers.get_default_storage_class()
>       assert len(tmp_default_sc) == 1, "More than 1 default storage class exist"
E       AssertionError: More than 1 default storage class exist
E       assert 2 == 1
E         +2
E         -1
```
This is happening because testcase is trying to firstly unset the default label from SC then setting the same for new storageclass. But label is not getting removed from already existing SC. 
```
[root@veera-419-tier2-cde2-bastion-0 ocs-ci]# oc get sc
NAME                                    PROVISIONER                             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
localblock                              kubernetes.io/no-provisioner            Delete          WaitForFirstConsumer   false                  4d19h
ocs-storagecluster-ceph-rbd (default)   openshift-storage.rbd.csi.ceph.com      Delete          Immediate              true                   4d19h
ocs-storagecluster-ceph-rgw             openshift-storage.ceph.rook.io/bucket   Delete          Immediate              false                  4d19h
ocs-storagecluster-cephfs               openshift-storage.cephfs.csi.ceph.com   Delete          Immediate              true                   4d19h
openshift-storage.noobaa.io             openshift-storage.noobaa.io/obc         Delete          Immediate              false                  4d19h

(venv) [root@veera-419-tier2-cde2-bastion-0 ocs-ci]# oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
storageclass.storage.k8s.io/ocs-storagecluster-ceph-rbd patched

(venv) [root@veera-419-tier2-cde2-bastion-0 ocs-ci]# oc get sc
NAME                                    PROVISIONER                             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
localblock                              kubernetes.io/no-provisioner            Delete          WaitForFirstConsumer   false                  4d19h
ocs-storagecluster-ceph-rbd (default)   openshift-storage.rbd.csi.ceph.com      Delete          Immediate              true                   4d19h
ocs-storagecluster-ceph-rgw             openshift-storage.ceph.rook.io/bucket   Delete          Immediate              false                  4d19h
ocs-storagecluster-cephfs               openshift-storage.cephfs.csi.ceph.com   Delete          Immediate              true                   4d19h
openshift-storage.noobaa.io             openshift-storage.noobaa.io/obc         Delete          Immediate              false                  4d19h
```
As per kubernetes, it allows only one StorageClass to be default.

So unless we set another one as default or explicitly remove the annotation (not just update it), the cluster keeps using it.