### PR TITLE
4.18 changes for zstream

### DIFF
--- a/files/ocs-ci/ocs-ci-20-setup.patch
+++ b/files/ocs-ci/ocs-ci-20-setup.patch
@@ -1,0 +1,44 @@
+diff --git a/setup.py b/setup.py
+index 9bd5e87cb..7ad7344b5 100644
+--- a/setup.py
++++ b/setup.py
+@@ -18,7 +18,7 @@ setup(
+     install_requires=[
+         "apache-libcloud==3.1.0",
+         "docopt==0.6.2",
+-        "gevent==23.9.1",
++        "gevent==25.4.2",
+         "ibm-cos-sdk==2.13.5",
+         "reportportal-client==3.2.3",
+         "requests==2.32.3",
+@@ -48,11 +48,11 @@ setup(
+         "google-cloud-storage==2.6.0",
+         "google-auth==2.14.1",
+         "elasticsearch==8.11.1",
+-        "numpy==1.23.2",
++        "numpy==1.26.4",
+         "pandas==1.5.2",
+         "tabulate==0.9.0",
+         "python-ipmi==0.4.2",
+-        "scipy==1.12.0",
++        "scipy==1.11.0",
+         "PrettyTable==0.7.2",
+         "azure-common==1.1.28",
+         "azure-mgmt-compute==33.0.0",
+@@ -72,7 +72,7 @@ setup(
+         # by default program attempting to load an x86_64-only library from a native arm64 process
+         # Beginning with gevent 20.12.0, 64-bit ARM binaries are distributed on PyPI for aarch64 manylinux2014
+         # compatible systems. Resolves problem for m1 Mac chips
+-        "greenlet==3.0rc3",
++        "greenlet==3.2.0",
+         "ovirt-engine-sdk-python==4.4.11",
+         "junitparser==3.1.0",
+         "flaky==3.7.0",
+@@ -102,6 +102,7 @@ setup(
+         "pytest-jira==0.3.21",
+         "certbot==3.0.0",
+         "certbot-dns-route53==3.0.0",
++        "marshmallow==3.26.1",
+     ],
+     entry_points={
+         "console_scripts": [


### PR DESCRIPTION
Setup Logs
```
ls: cannot access '../../files/ocs-ci/kvm/ocs-ci-*[0-9][0-9]-*.patch': No such file or directory
platform_patchfiles=
Generating consolidated patch file /root/ocs-ci.patch from /root/ocs-upi-kvm/files/ocs-ci/
checking file ocs_ci/ocs/benchmark_operator.py
checking file ocs_ci/ocs/amq.py
checking file ocs_ci/templates/workloads/amq/benchmark/values.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
checking file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
checking file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
checking file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
checking file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
checking file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
checking file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
checking file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
checking file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
checking file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
checking file ocs_ci/ocs/node.py
checking file ocs_ci/deployment/deployment.py
checking file ocs_ci/templates/workloads/amq/kafkadrop.yaml
checking file ocs_ci/ocs/resources/storage_cluster.py
checking file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
checking file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
checking file ocs_ci/deployment/helpers/lso_helpers.py
checking file tests/functional/z_cluster/test_ceph_default_values_check.py
checking file tests/functional/z_cluster/test_must_gather.py
checking file tests/functional/object/mcg/test_s3_with_java_sdk.py
checking file tests/functional/object/mcg/test_noobaa_secret.py
checking file tests/functional/z_cluster/test_hugepages.py
checking file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
checking file tests/functional/object/mcg/test_mcg_resources_disruptions.py
checking file tests/functional/object/mcg/test_host_node_failure.py
checking file tests/functional/z_cluster/nodes/test_nodes_restart.py
checking file ocs_ci/helpers/helpers.py
checking file ocs_ci/utility/deployment.py
checking file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
checking file ocs_ci/templates/CSI/cephfs/pod.yaml
checking file ocs_ci/templates/CSI/rbd/pod.yaml
checking file ocs_ci/templates/app-pods/nginx.yaml
checking file ocs_ci/templates/app-pods/raw_block_pod.yaml
checking file tests/functional/z_cluster/nodes/test_nodes_maintenance.py
checking file tests/functional/storageclass/test_replica1.py
checking file ocs_ci/ocs/ceph_debug.py
checking file setup.py
Patching ocs-ci...
patching file ocs_ci/ocs/benchmark_operator.py
patching file ocs_ci/ocs/amq.py
patching file ocs_ci/templates/workloads/amq/benchmark/values.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-consumer.yaml
patching file ocs_ci/templates/workloads/amq/hello-world-producer.yaml
patching file tests/cross_functional/scale/test_scale_osds_fill_75%_reboot_workers.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
patching file tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
patching file tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
patching file tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
patching file tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
patching file tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
patching file tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
patching file tests/cross_functional/scale/test_pv_scale_and_respin_ceph_pods.py
patching file ocs_ci/ocs/node.py
patching file ocs_ci/deployment/deployment.py
patching file ocs_ci/templates/workloads/amq/kafkadrop.yaml
patching file ocs_ci/ocs/resources/storage_cluster.py
patching file ocs_ci/templates/workloads/logwriter/cephfs.logreader.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.logwriter.yaml
patching file ocs_ci/templates/workloads/logwriter/cephfs.reproducer.yaml
patching file ocs_ci/deployment/helpers/lso_helpers.py
patching file tests/functional/z_cluster/test_ceph_default_values_check.py
patching file tests/functional/z_cluster/test_must_gather.py
patching file tests/functional/object/mcg/test_s3_with_java_sdk.py
patching file tests/functional/object/mcg/test_noobaa_secret.py
patching file tests/functional/z_cluster/test_hugepages.py
patching file tests/functional/monitoring/prometheus/alerts/test_noobaa.py
patching file tests/functional/object/mcg/test_mcg_resources_disruptions.py
patching file tests/functional/object/mcg/test_host_node_failure.py
patching file tests/functional/z_cluster/nodes/test_nodes_restart.py
patching file ocs_ci/helpers/helpers.py
patching file ocs_ci/utility/deployment.py
patching file tests/functional/z_cluster/test_rook_ceph_log_rotate.py
patching file ocs_ci/templates/CSI/cephfs/pod.yaml
patching file ocs_ci/templates/CSI/rbd/pod.yaml
patching file ocs_ci/templates/app-pods/nginx.yaml
patching file ocs_ci/templates/app-pods/raw_block_pod.yaml
patching file tests/functional/z_cluster/nodes/test_nodes_maintenance.py
patching file tests/functional/storageclass/test_replica1.py
patching file ocs_ci/ocs/ceph_debug.py
patching file setup.py
Requirement already satisfied: pip in /root/venv/lib/python3.9/site-packages (21.3.1)
Collecting pip
```